### PR TITLE
Allow manual setting of MIDI control change numbers

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -838,7 +838,7 @@ class ChannelPropertiesDialog(Gtk.Dialog):
             timeout_label.set_text('This window will close in %d seconds.' % window.timeout)
             if window.timeout == 0:
                 window.destroy()
-                entry.set_text('%s' % self.mixer.last_midi_channel)
+                entry.set_value(self.mixer.last_midi_channel)
                 return False
             return True
         window.show_all()

--- a/jack_mixer.c
+++ b/jack_mixer.c
@@ -355,15 +355,12 @@ channel_set_solo_midi_cc(
 }
 
 void
-channel_autoset_midi_cc(
+channel_autoset_volume_midi_cc(
   jack_mixer_channel_t channel)
 {
-  struct jack_mixer *mixer_ptr;
-  int i;
+  struct jack_mixer *mixer_ptr = channel_ptr->mixer_ptr;
 
-  mixer_ptr = channel_ptr->mixer_ptr;
-
-  for (i = 11 ; i < 128 ; i++)
+  for (int i = 11 ; i < 128 ; i++)
   {
     if (mixer_ptr->midi_cc_map[i] == NULL)
     {
@@ -375,8 +372,15 @@ channel_autoset_midi_cc(
       break;
     }
   }
+}
 
-  for (; i < 128 ; i++)
+void
+channel_autoset_balance_midi_cc(
+  jack_mixer_channel_t channel)
+{
+  struct jack_mixer *mixer_ptr = channel_ptr->mixer_ptr;
+
+  for (int i = 11; i < 128 ; i++)
   {
     if (mixer_ptr->midi_cc_map[i] == NULL)
     {
@@ -388,8 +392,15 @@ channel_autoset_midi_cc(
       break;
     }
   }
+}
 
-  for (; i < 128 ; i++)
+void
+channel_autoset_mute_midi_cc(
+  jack_mixer_channel_t channel)
+{
+  struct jack_mixer *mixer_ptr = channel_ptr->mixer_ptr;
+
+  for (int i = 11; i < 128 ; i++)
   {
     if (mixer_ptr->midi_cc_map[i] == NULL)
     {
@@ -401,8 +412,15 @@ channel_autoset_midi_cc(
       break;
     }
   }
+}
 
-  for (; i < 128 ; i++)
+void
+channel_autoset_solo_midi_cc(
+  jack_mixer_channel_t channel)
+{
+  struct jack_mixer *mixer_ptr = channel_ptr->mixer_ptr;
+
+  for (int i = 11; i < 128 ; i++)
   {
     if (mixer_ptr->midi_cc_map[i] == NULL)
     {

--- a/jack_mixer.h
+++ b/jack_mixer.h
@@ -159,7 +159,19 @@ channel_set_solo_midi_cc(
   int new_cc);
 
 void
-channel_autoset_midi_cc(
+channel_autoset_volume_midi_cc(
+  jack_mixer_channel_t channel);
+
+void
+channel_autoset_balance_midi_cc(
+  jack_mixer_channel_t channel);
+
+void
+channel_autoset_mute_midi_cc(
+  jack_mixer_channel_t channel);
+
+void
+channel_autoset_solo_midi_cc(
   jack_mixer_channel_t channel);
 
 void

--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -417,17 +417,22 @@ class JackMixer(SerializedObject):
             err.run()
             err.destroy()
             return
-        if volume_cc != '-1':
-            channel.channel.volume_midi_cc = int(volume_cc)
-        if balance_cc != '-1':
-            channel.channel.balance_midi_cc = int(balance_cc)
-        if mute_cc != '-1':
-            channel.channel.mute_midi_cc = int(mute_cc)
-        if solo_cc != '-1':
-            channel.channel.solo_midi_cc = int(solo_cc)
-        if (volume_cc == '-1' and balance_cc == '-1' and mute_cc == '-1' and solo_cc == '-1'):
-            channel.channel.autoset_midi_cc()
-
+        if volume_cc != -1:
+            channel.channel.volume_midi_cc = volume_cc
+        else:
+            channel.channel.autoset_volume_midi_cc()
+        if balance_cc != -1:
+            channel.channel.balance_midi_cc = balance_cc
+        else:
+            channel.channel.autoset_balance_midi_cc()
+        if mute_cc != -1:
+            channel.channel.mute_midi_cc = mute_cc
+        else:
+            channel.channel.autoset_mute_midi_cc()
+        if solo_cc != -1:
+            channel.channel.solo_midi_cc = solo_cc
+        else:
+            channel.channel.autoset_solo_midi_cc()
         return channel
 
     def add_channel_precreated(self, channel):
@@ -483,12 +488,19 @@ class JackMixer(SerializedObject):
             err.run()
             err.destroy()
             return
-        if volume_cc != '-1':
-            channel.channel.volume_midi_cc = int(volume_cc)
-        if balance_cc != '-1':
-            channel.channel.balance_midi_cc = int(balance_cc)
-        if mute_cc != '-1':
-            channel.channel.mute_midi_cc = int(mute_cc)
+
+        if volume_cc != -1:
+            channel.channel.volume_midi_cc = volume_cc
+        else:
+            channel.channel.autoset_volume_midi_cc()
+        if balance_cc != -1:
+            channel.channel.balance_midi_cc = balance_cc
+        else:
+            channel.channel.autoset_balance_midi_cc()
+        if mute_cc != -1:
+            channel.channel.mute_midi_cc = mute_cc
+        else:
+            channel.channel.autoset_mute_midi_cc()
         return channel
 
     def add_output_channel_precreated(self, channel):

--- a/jack_mixer_c.c
+++ b/jack_mixer_c.c
@@ -557,17 +557,51 @@ Channel_remove(ChannelObject *self, PyObject *args)
 }
 
 static PyObject*
-Channel_autoset_midi_cc(ChannelObject *self, PyObject *args)
+Channel_autoset_volume_midi_cc(ChannelObject *self, PyObject *args)
 {
 	if (! PyArg_ParseTuple(args, "")) return NULL;
-	channel_autoset_midi_cc(self->channel);
+	channel_autoset_volume_midi_cc(self->channel);
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject*
+Channel_autoset_balance_midi_cc(ChannelObject *self, PyObject *args)
+{
+	if (! PyArg_ParseTuple(args, "")) return NULL;
+	channel_autoset_balance_midi_cc(self->channel);
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject*
+Channel_autoset_mute_midi_cc(ChannelObject *self, PyObject *args)
+{
+	if (! PyArg_ParseTuple(args, "")) return NULL;
+	channel_autoset_mute_midi_cc(self->channel);
+	Py_INCREF(Py_None);
+	return Py_None;
+}
+
+static PyObject*
+Channel_autoset_solo_midi_cc(ChannelObject *self, PyObject *args)
+{
+	if (! PyArg_ParseTuple(args, "")) return NULL;
+	channel_autoset_solo_midi_cc(self->channel);
 	Py_INCREF(Py_None);
 	return Py_None;
 }
 
 static PyMethodDef channel_methods[] = {
 	{"remove", (PyCFunction)Channel_remove, METH_VARARGS, "Remove"},
-	{"autoset_midi_cc", (PyCFunction)Channel_autoset_midi_cc, METH_VARARGS, "Autoset MIDI CC"},
+	{"autoset_volume_midi_cc",
+		(PyCFunction)Channel_autoset_volume_midi_cc, METH_VARARGS, "Autoset Volume MIDI CC"},
+	{"autoset_balance_midi_cc",
+		(PyCFunction)Channel_autoset_balance_midi_cc, METH_VARARGS, "Autoset Balance MIDI CC"},
+	{"autoset_mute_midi_cc",
+		(PyCFunction)Channel_autoset_mute_midi_cc, METH_VARARGS, "Autoset Mute MIDI CC"},
+	{"autoset_solo_midi_cc",
+		(PyCFunction)Channel_autoset_solo_midi_cc, METH_VARARGS, "Autoset Solo MIDI CC"},
 	{NULL}
 };
 


### PR DESCRIPTION
* Changes controls for MIDI controllers in channel new / edit dialog to `Gtk.SpinButton`s with range (-1, 127).
* Adds tooltip to controls.
* Changes `Channel` object in C extension to add methods for auto-assigning the CC # for each control (volume, balance, mute, solo) individually.
* When editing channel, channel is only renamed when name actually changes.

Using `SpinButton`s also simplifies handling of the widget values, because they are always numeric and in range, they just have to be converted from `float` to `int`.

One minor disadvantage of `SpinButton`s is that if you enter a value manually via the text entry, it only updates when the focus leaves the widget, e.g. when you  tab to the next one. So if you enter a value in, say, the "Volume" spin button text entry and then immediately activate the "Add/Apply" button (e.g. via a keyboard shortcut), the widget value will still have the previous value.

This also fixes a buggy behaviour of jack_mixer, where, if you assigned a CC to only one of the controls, and the others still had the default value -1, they would not get auto-assigned.