### PR TITLE
Add accelerator shortcuts to menu items

### DIFF
--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -162,13 +162,13 @@ class JackMixer(SerializedObject):
         edit_menu = Gtk.Menu()
         edit_menu_item.set_submenu(edit_menu)
 
-        self.channel_edit_input_menu_item = self.new_menu_item('Edit _Input Channel',
+        self.channel_edit_input_menu_item = self.new_menu_item('_Edit Input Channel',
                                                                enabled=False)
         edit_menu.append(self.channel_edit_input_menu_item)
         self.channel_edit_input_menu = Gtk.Menu()
         self.channel_edit_input_menu_item.set_submenu(self.channel_edit_input_menu)
 
-        self.channel_edit_output_menu_item = self.new_menu_item('Edit _Output Channel',
+        self.channel_edit_output_menu_item = self.new_menu_item('E_dit Output Channel',
                                                                 enabled=False)
         edit_menu.append(self.channel_edit_output_menu_item)
         self.channel_edit_output_menu = Gtk.Menu()


### PR DESCRIPTION
* Rename "Open" menu item to "Open...".
* Rename "SaveAs" menu item to "Save As...".
* Change some menu item mnemonics:
  * "New Output _Channel" (different from "_Open...")
  * "_Edit Input Channel"
  * "E_dit Output Channel"
  * "_Remove Input Channel"
  * "Re_move Ouput Channel"
  * "_Clear" (added)
* Disable "Edit/Remove Input Channel" sub-menu entries initially and when no input channels are left.
* Same for output channels.