### PR TITLE
Use standard-logging module instead of scattered print calls

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -15,10 +15,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import configparser
+import logging
+import os
+
 import gi
 from gi.repository import GObject
-import os
-import configparser
 from serialization import SerializedObject
 
 try:
@@ -27,11 +29,16 @@ try:
 except:
     xdg = None
 
+
+log = logging.getLogger(__name__)
+
+
 def lookup_scale(scales, scale_id):
     for scale in scales:
         if scale_id == scale.scale_id:
             return scale
     return None
+
 
 class Factory(GObject.GObject, SerializedObject):
 
@@ -50,7 +57,8 @@ class Factory(GObject.GObject, SerializedObject):
             else:
                 self.write_preferences()
         else:
-            print("Cannot load PyXDG. Your preferences will not be preserved across jack_mixer invocations")
+            log.warning("Cannot load PyXDG. Your preferences will not be preserved across "
+                        "jack_mixer invocations")
 
     def set_default_preferences(self):
         self.default_meter_scale = self.meter_scales[0]
@@ -65,7 +73,7 @@ class Factory(GObject.GObject, SerializedObject):
         scale_id = self.config['Preferences']['default_meter_scale']
         self.default_meter_scale = lookup_scale(self.meter_scales, scale_id)
         if not self.default_meter_scale:
-            self.default_meter_scale = meter_scales[0]
+            self.default_meter_scale = self.meter_scales[0]
 
         scale_id = self.config['Preferences']['default_slider_scale']
         self.default_slider_scale = lookup_scale(self.slider_scales, scale_id)
@@ -106,7 +114,8 @@ class Factory(GObject.GObject, SerializedObject):
                 self.write_preferences()
             self.emit("default-meter-scale-changed", self.default_meter_scale)
         else:
-            print("Ignoring default_meter_scale setting, because \"%s\" scale is not known" % scale_id)
+            log.warning('Ignoring default_meter_scale setting, because "%s" scale is not known.',
+                        scale)
 
     def set_default_slider_scale(self, scale):
         if scale:
@@ -115,7 +124,8 @@ class Factory(GObject.GObject, SerializedObject):
                 self.write_preferences()
             self.emit("default-slider-scale-changed", self.default_slider_scale)
         else:
-            print("Ignoring default_slider_scale setting, because \"%s\" scale is not known" % scale_id)
+            log.warning('Ignoring default_slider_scale setting, because "%s" scale is not known.',
+                        scale)
 
     def set_vumeter_color(self, color):
         self.vumeter_color = color
@@ -195,6 +205,7 @@ class Factory(GObject.GObject, SerializedObject):
             self.set_midi_behavior_mode(int(value))
             return True
         return False
+
 
 GObject.signal_new("default-meter-scale-changed", Factory,
                 GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,

--- a/meter.py
+++ b/meter.py
@@ -15,10 +15,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import logging
+
+import cairo
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
-import cairo
+
+
+log = logging.getLogger(__name__)
+
 
 class MeterWidget(Gtk.DrawingArea):
     def __init__(self, scale):
@@ -38,7 +44,7 @@ class MeterWidget(Gtk.DrawingArea):
         self.cache_surface = None
 
     def get_preferred_width(self):
-        print('get_preferred_width called')
+        log.debug('get_preferred_width called')
         return 2
 
     def get_preferred_height(self):
@@ -67,7 +73,7 @@ class MeterWidget(Gtk.DrawingArea):
         self.cache_surface = None
 
     def on_size_request(self, widget, requisition):
-        #print "size-request, %u x %u" % (requisition.width, requisition.height)
+        log.debug("size-request, %u x %u", requisition.width, requisition.height)
         requisition.width = 20
         return
 
@@ -121,6 +127,7 @@ class MeterWidget(Gtk.DrawingArea):
         self.cache_surface = None
         self.invalidate_all()
 
+
 class MonoMeterWidget(MeterWidget):
     def __init__(self, scale):
         MeterWidget.__init__(self, scale)
@@ -143,6 +150,7 @@ class MonoMeterWidget(MeterWidget):
         self.value = self.scale.db_to_scale(value)
         if (abs(old_value-self.value) * self.height) > 1:
             self.invalidate_all()
+
 
 class StereoMeterWidget(MeterWidget):
     def __init__(self, scale):

--- a/scale.py
+++ b/scale.py
@@ -15,8 +15,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import logging
 import math
+
 import jack_mixer_c
+
+
+log = logging.getLogger(__name__)
+
 
 class Mark:
     '''Encapsulates scale linear function edge and coefficients for scale = a * dB + b formula'''
@@ -24,6 +30,7 @@ class Mark:
         self.db = db
         self.scale = scale
         self.text = "%.0f" % math.fabs(db)
+
 
 class Base:
     '''Scale abstraction, various scale implementation derive from this class'''
@@ -43,7 +50,7 @@ class Base:
 
     def db_to_scale(self, db):
         '''Convert dBFS value to number in range 0.0-1.0 used in GUI'''
-        #print "db_to_scale(%f)" % db
+        log.debug("db_to_scale(%f)", db)
         return self.scale.db_to_scale(db)
 
     def scale_to_db(self, scale):
@@ -60,6 +67,7 @@ class Base:
         for i in self.marks:
             if i.scale == -1.0:
                 i.scale = self.db_to_scale(i.db)
+
 
 # IEC 60268-18 Peak programme level meters - Digital audio peak level meter
 # Adapted from meterpridge, may be wrong, I'm not buying standards, event if they cost $45
@@ -84,6 +92,7 @@ class IEC268(Base):
         self.calculate_coefficients()
         self.scale_marks()
 
+
 class IEC268Minimalistic(Base):
     '''IEC 60268-18 Peak programme level meters - Digital audio peak level meter,
        fewer marks'''
@@ -100,6 +109,7 @@ class IEC268Minimalistic(Base):
         self.add_threshold(0.0, 1.0, True)
         self.calculate_coefficients()
         self.scale_marks()
+
 
 class Linear70dB(Base):
     '''Linear scale with range from -70 to 0 dBFS'''
@@ -120,6 +130,7 @@ class Linear70dB(Base):
         self.calculate_coefficients()
         self.scale_marks()
 
+
 class Linear30dB(Base):
     '''Linear scale with range from -30 to +30 dBFS'''
     def __init__(self):
@@ -129,24 +140,29 @@ class Linear30dB(Base):
         self.calculate_coefficients()
         self.scale_marks()
 
+
 def scale_test1(scale):
     for i in range(-97 * 2, 1, 1):
         db = float(i)/2.0
         print("%5.1f dB maps to %f" % (db, scale.db_to_scale(db)))
+
 
 def scale_test2(scale):
     for i in range(101):
         s = float(i)/100.0
         print("%.2f maps to %.1f dB" % (s, scale.scale_to_db(s)))
 
+
 def print_db_to_scale(db):
     print("%-.1f dB maps to %f" % (db, scale.db_to_scale(db)))
+
 
 def scale_test3(scale):
     print_db_to_scale(+77.0)
     print_db_to_scale(+7.0)
     print_db_to_scale(0.0)
     print_db_to_scale(-107.0)
+
 
 #scale = linear_30dB()
 #scale_test2(scale)

--- a/serialization.py
+++ b/serialization.py
@@ -15,6 +15,12 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
 class SerializationBackend:
     '''Base class for serialization backends'''
     def get_root_serialization_object(self, name):
@@ -26,6 +32,7 @@ class SerializationBackend:
     def get_child_serialization_object(self, name, backend_object):
         # this method should never be called for the base class
         raise NotImplementedError
+
 
 class SerializationObjectBackend:
     '''Base class for serialization backend objects where real object
@@ -42,6 +49,7 @@ class SerializationObjectBackend:
 
     def serialization_name(self):
         return None
+
 
 class SerializedObject:
     '''Base class for object supporting serialization'''
@@ -62,6 +70,7 @@ class SerializedObject:
     def unserialize_child(self, name):
         return None
 
+
 class Serializator:
     def __init__(self):
         pass
@@ -77,10 +86,10 @@ class Serializator:
         return self.unserialize_one(backend, root, backend_object)
 
     def unserialize_one(self, backend, object, backend_object):
-        #print "Unserializing " + repr(object)
+        log.debug("Unserializing %r.", object)
         properties = backend_object.get_properties()
         for name, value in properties.items():
-            #print "%s = %s" % (name, value)
+            log.debug("%s = %s", name, value)
             if not object.unserialize_property(name, value):
                 return False
 
@@ -99,7 +108,7 @@ class Serializator:
         object.serialize(backend_object)
         childs = object.serialization_get_childs()
         for child in childs:
-            #print "serializing child " + repr(child)
+            log.debug("Serializing child %r.", child)
             self.serialize_one(backend, child,
                                backend.get_child_serialization_object(
                                        child.serialization_name(), backend_object))

--- a/slider.py
+++ b/slider.py
@@ -15,10 +15,16 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import logging
+
+import cairo
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
-import cairo
+
+
+log = logging.getLogger(__name__)
+
 
 class AdjustmentdBFS(Gtk.Adjustment):
     def __init__(self, scale, default_db, step_inc):
@@ -189,12 +195,12 @@ class CustomSliderWidget(Gtk.DrawingArea):
 
     def on_mouse(self, widget, event):
         if event.type == Gdk.EventType.BUTTON_PRESS:
-            #print "mouse button %u pressed %u:%u" % (event.button, event.x, event.y)
+            log.debug("Mouse button %u pressed %ux%u", event.button, event.x, event.y)
             if event.button == 1:
                 if event.y >= self.slider_rail_up and event.y < self.slider_rail_up + self.slider_rail_height:
                     self.adjustment.set_value(1 - float(event.y - self.slider_rail_up)/float(self.slider_rail_height))
         elif event.type == Gdk.EventType.MOTION_NOTIFY:
-            #print "mouse motion %u:%u" % (event.x, event.y)
+            log.debug("Mouse motion %ux%u", event.x, event.y)
             if event.y < self.slider_rail_up:
                 y = self.slider_rail_up
             elif event.y > self.slider_rail_up + self.slider_rail_height:


### PR DESCRIPTION
I inserted `log.debug` or `log.warning` calls everywhere where `print()` was used (except test functions in `scale.py` and `test.py`) even if `print` was commented out. I used `log.exception` in one instance, when the creation of the main application instance fails, to give an exception traceback in the logging output, because the GUI dialog only shows the general error message, which isn't that helpful.

Debug logging can be turned on with the `-d/--debug` command line switch.

Logging from the C code is currently independent of this and so not affected by the log level or format settings. I'm looking into integrating this in a subsequent PR.

When I touched a `.py` file I also sorted the imports and did some white-space changes according to PEP-8 (mainly two empty lines between top-level function/classes). If you want me to leave that out from the PR, let me know.