### PR TITLE
Minor C logging tweaks

### DIFF
--- a/jack_mixer.c
+++ b/jack_mixer.c
@@ -47,8 +47,8 @@
 
 #define PEAK_FRAMES_CHUNK 4800
 
-// we don't know how much to allocate, but we don't want to wait with 
-// allocating until we're in the process() callback, so we just take a 
+// we don't know how much to allocate, but we don't want to wait with
+// allocating until we're in the process() callback, so we just take a
 // fairly big chunk: 4 periods per buffer, 4096 samples per period.
 // (not sure if the '*4' is needed)
 #define MAX_BLOCK_SIZE (4 * 4096)
@@ -98,7 +98,7 @@ struct channel
   int midi_cc_solo_index;
   bool midi_cc_volume_picked_up;
   bool midi_cc_balance_picked_up;
-  
+
   jack_default_audio_sample_t * left_buffer_ptr;
   jack_default_audio_sample_t * right_buffer_ptr;
 
@@ -384,7 +384,7 @@ channel_autoset_volume_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_volume_index = i;
 
-      LOG_NOTICE("New channel \"%s\" volume mapped to CC#%i", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" volume mapped to CC#%i", channel_ptr->name, i);
 
       break;
     }
@@ -404,7 +404,7 @@ channel_autoset_balance_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_balance_index = i;
 
-      LOG_NOTICE("New channel \"%s\" balance mapped to CC#%i", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" balance mapped to CC#%i", channel_ptr->name, i);
 
       break;
     }
@@ -424,7 +424,7 @@ channel_autoset_mute_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_mute_index = i;
 
-      LOG_NOTICE("New channel \"%s\" mute mapped to CC#%i", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" mute mapped to CC#%i", channel_ptr->name, i);
 
       break;
     }
@@ -444,7 +444,7 @@ channel_autoset_solo_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_solo_index = i;
 
-      LOG_NOTICE("New channel \"%s\" solo mapped to CC#%i", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" solo mapped to CC#%i", channel_ptr->name, i);
 
       break;
     }
@@ -496,12 +496,12 @@ remove_channel(
     assert(channel_ptr->mixer_ptr->midi_cc_map[channel_ptr->midi_cc_solo_index] == channel_ptr);
     channel_ptr->mixer_ptr->midi_cc_map[channel_ptr->midi_cc_solo_index] = NULL;
   }
-  
+
   free(channel_ptr->frames_left);
   free(channel_ptr->frames_right);
   free(channel_ptr->prefader_frames_left);
   free(channel_ptr->prefader_frames_right);
-  
+
   free(channel_ptr);
 }
 
@@ -720,7 +720,7 @@ mix_one(
     }
 
     if ((!channel_ptr->mixer_ptr->soloed_channels && !output_mix_channel->soloed_channels) ||
-        (channel_ptr->mixer_ptr->soloed_channels && 
+        (channel_ptr->mixer_ptr->soloed_channels &&
          g_slist_find(channel_ptr->mixer_ptr->soloed_channels, channel_ptr) != NULL) ||
         (output_mix_channel->soloed_channels &&
         g_slist_find(output_mix_channel->soloed_channels, channel_ptr) != NULL)) {
@@ -1058,7 +1058,7 @@ process(
     update_channel_buffers(channel_ptr, nframes);
   }
 
-  // Fill output buffers with the input 
+  // Fill output buffers with the input
   for (node_ptr = mixer_ptr->output_channels_list; node_ptr; node_ptr = g_slist_next(node_ptr))
   {
     channel_ptr = node_ptr->data;

--- a/log.c
+++ b/log.c
@@ -31,6 +31,6 @@ void jack_mixer_log(int level, const char * format, ...)
   va_list arglist;
 
   va_start(arglist, format);
-  vprintf(format, arglist);
+  vfprintf(stderr, format, arglist);
   va_end(arglist);
 }


### PR DESCRIPTION
To change the log level for the C code, add e.g. `-DLOG_LEVEL=0` to `CFLAGS` when compiling, for example via the environment. The log levels are defined in `log.h`.

