### PR TITLE
Coerce midi_behaviour_mode preference setting to int

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -91,7 +91,7 @@ class Factory(GObject.GObject, SerializedObject):
         self.use_custom_widgets = self.config["Preferences"]["use_custom_widgets"] == 'True'
 
         try:
-            self.midi_behavior_mode = self.config["Preferences"]["midi_behavior_mode"]
+            self.midi_behavior_mode = int(self.config["Preferences"]["midi_behavior_mode"])
         except:
             self.midi_behavior_mode = 0
 


### PR DESCRIPTION
Makes setting consistently an int when stored internally, as it already is when read from XML.