### PR TITLE
Channel strip UI layout and code improvements

### DIFF
--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -217,8 +217,8 @@ class JackMixer(SerializedObject):
         self.channel_remove_output_menu_item.set_submenu(self.channel_remove_output_menu)
 
         edit_menu.append(Gtk.SeparatorMenuItem())
-        edit_menu.append(self.new_menu_item('Shrink Input Channels', self.on_narrow_input_channels_cb, "<Control>minus"))
-        edit_menu.append(self.new_menu_item('Expand Input Channels', self.on_widen_input_channels_cb, "<Control>plus"))
+        edit_menu.append(self.new_menu_item('Shrink Channels', self.on_shrink_channels_cb, "<Control>minus"))
+        edit_menu.append(self.new_menu_item('Expand Channels', self.on_expand_channels_cb, "<Control>plus"))
         edit_menu.append(Gtk.SeparatorMenuItem())
 
         edit_menu.append(self.new_menu_item('_Clear', self.on_channels_clear, "<Control>X"))
@@ -380,12 +380,12 @@ class JackMixer(SerializedObject):
 
         Gtk.main_quit()
 
-    def on_narrow_input_channels_cb(self, widget):
-        for channel in self.channels:
+    def on_shrink_channels_cb(self, widget):
+        for channel in self.channels + self.output_channels:
             channel.narrow()
 
-    def on_widen_input_channels_cb(self, widget):
-        for channel in self.channels:
+    def on_expand_channels_cb(self, widget):
+        for channel in self.channels + self.output_channels:
             channel.widen()
 
     preferences_dialog = None
@@ -799,6 +799,14 @@ Franklin Street, Fifth Floor, Boston, MA 02110-130159 USA""")
         width, height = self.window.get_size()
         if self.visible or not from_nsm:
             self.window.show_all()
+
+        if self.output_channels:
+            self.output_channels[-1].volume_digits.select_region(0,0)
+            self.output_channels[-1].slider.grab_focus()
+        elif self.channels:
+            self.channels[-1].volume_digits.select_region(0,0)
+            self.channels[-1].volume_digits.grab_focus()
+
         self.paned.set_position(self.paned_position/self.width*width)
         self.window.resize(self.width, self.height)
 

--- a/slider.py
+++ b/slider.py
@@ -178,14 +178,20 @@ class BalanceSlider(Gtk.Scale):
         self.set_adjustment(adjustment)
         self.set_has_origin(False)
         self.set_draw_value(False)
+        self.set_property("has-tooltip", True)
         self._preferred_width = preferred_width
         self._preferred_height = preferred_height
         self._button_down = False
 
-        self.connect('button-press-event', self.on_button_press_event)
-        self.connect('button-release-event', self.on_button_release_event)
+        self.add_mark(-1.0, Gtk.PositionType.TOP)
+        self.add_mark(0.0, Gtk.PositionType.TOP)
+        self.add_mark(1.0, Gtk.PositionType.TOP)
+
+        self.connect("button-press-event", self.on_button_press_event)
+        self.connect("button-release-event", self.on_button_release_event)
         self.connect("motion-notify-event", self.on_motion_notify_event)
         self.connect("scroll-event", self.on_scroll_event)
+        self.connect("query-tooltip", self.on_query_tooltip)
 
     def get_preferred_width(self):
         return self._preferred_width
@@ -223,6 +229,15 @@ class BalanceSlider(Gtk.Scale):
             return True
 
         return False
+
+    def on_query_tooltip(self, widget, x, y, keyboard_mode, tooltip, *args):
+        val = int(self.adjustment.get_value() * 50)
+        if val == 0:
+            tooltip.set_text("Center")
+        else:
+            tooltip.set_text("Left: %s / Right: %d" % (50 - val, val + 50))
+
+        return True
 
     def on_scroll_event(self, widget, event):
         delta = self.get_adjustment().get_step_increment()


### PR DESCRIPTION
* Overhaul channel fader/meter layout:
  * Put value readout/edit entry and peak value readout next to each other
    above the fader and meter. When channels are shrunk, they are displayed
    one under the other.
  * Add tick marks for left/center/right on balance slider
    and add tooltip displaying left/right value. This also
    changes the appearance of slider handle depending on theme.
  * Convert occurences of `Gtk.HBox` and `Gtk.VBox` to `Gtk.Box`.
  * Remove `Gtk.Frame`s from layout and set border style via CSS where needed.
* You can now shrink the width of input *and* output channels and it also
  reduces the width of the meter display.
* On project load, give input focus to fader of last added channel and deselect
  volume entry widget.
* Some code reorganization and cleanup in `abspeak`, `channel`, and `meter`
  module:
  * Refactor channel strip UI creation to reduce DRY.
  * Use `super()` instead of directly accessing the super-class where
    appropriate
  * Unify `widen` and `narrow` `Channel` methods.
  * Remove outdated size request handling methods in `MeterWidget`.
  * Style context getter for `AbspeakWidget` returns context for wrapped label
    widget.

Fixes: #67
