### PR TITLE
jack_mixer and channel modules and MIDI CC assignment refactoring and cleanup

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -920,7 +920,6 @@ class ChannelPropertiesDialog(Gtk.Dialog):
 
     def fill_and_show(self):
         self.fill_ui()
-        self.show()
         self.present()
 
     def add_buttons(self):
@@ -1101,6 +1100,7 @@ class ChannelPropertiesDialog(Gtk.Dialog):
                         setattr(self.channel.channel, '{}_midi_cc'.format(control), value)
 
         self.hide()
+        return True
 
     def on_entry_name_changed(self, entry):
         sensitive = False
@@ -1196,7 +1196,7 @@ class OutputChannelPropertiesDialog(ChannelPropertiesDialog):
             for inputchannel in self.app.channels:
                 inputchannel.update_control_group(self.channel)
 
-        super().on_response_cb(dlg, response_id, *args)
+        return super().on_response_cb(dlg, response_id, *args)
 
 
 class NewOutputChannelDialog(NewChannelDialog, OutputChannelPropertiesDialog):

--- a/channel.py
+++ b/channel.py
@@ -422,6 +422,48 @@ class Channel(Gtk.VBox, SerializedObject):
                 self.monitor_button.set_active(True)
                 self.monitor_button.handler_unblock_by_func(self.on_monitor_button_toggled)
 
+    def assign_midi_ccs(self, volume_cc, balance_cc, mute_cc, solo_cc=None):
+        try:
+            if volume_cc != -1:
+                self.channel.volume_midi_cc = volume_cc
+            else:
+                volume_cc = self.channel.autoset_volume_midi_cc()
+
+            log.debug("Channel '%s' volume assigned to CC #%s.", self.channel.name, volume_cc)
+        except Exception as exc:
+            log.error("Channel '%s' volume CC assignment failed: %s", self.channel.name, exc)
+
+        try:
+            if balance_cc != -1:
+                self.channel.balance_midi_cc = balance_cc
+            else:
+                balance_cc = self.channel.autoset_balance_midi_cc()
+
+            log.debug("Channel '%s' balance assigned to CC #%s.", self.channel.name, balance_cc)
+        except Exception as exc:
+            log.error("Channel '%s' balance CC assignment failed: %s", self.channel.name, exc)
+
+        try:
+            if mute_cc != -1:
+                self.channel.mute_midi_cc = mute_cc
+            else:
+                mute_cc = self.channel.autoset_mute_midi_cc()
+
+            log.debug("Channel '%s' mute assigned to CC #%s.", self.channel.name, mute_cc)
+        except Exception as exc:
+            log.error("Channel '%s' mute CC assignment failed: %s", self.channel.name, exc)
+
+        if solo_cc is not None:
+            try:
+                if solo_cc != -1:
+                    self.channel.solo_midi_cc = solo_cc
+                else:
+                    solo_cc = self.channel.autoset_solo_midi_cc()
+
+                log.debug("Channel '%s' solo assigned to CC #%s.", self.channel.name, solo_cc)
+            except Exception as exc:
+                log.error("Channel '%s' solo CC assignment failed: %s", self.channel.name, exc)
+
     # ---------------------------------------------------------------------------------------------
     # Channel operations
 

--- a/jack_mixer.c
+++ b/jack_mixer.c
@@ -290,15 +290,19 @@ channel_get_balance_midi_cc(
 static void
 channel_unset_midi_cc_map(
   jack_mixer_channel_t channel,
-  int new_cc) {
+  int new_cc)
+{
   if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_volume_index == new_cc) {
     channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_volume_index = -1;
-  } else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_balance_index == new_cc) {
-  channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_balance_index = -1;
-  } else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_mute_index == new_cc) {
-  channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_mute_index = -1;
-  } else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_solo_index == new_cc) {
-  channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_solo_index = -1;
+  }
+  else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_balance_index == new_cc) {
+    channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_balance_index = -1;
+  }
+  else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_mute_index == new_cc) {
+    channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_mute_index = -1;
+  }
+  else if (channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_solo_index == new_cc) {
+    channel_ptr->mixer_ptr->midi_cc_map[new_cc]->midi_cc_solo_index = -1;
   }
 }
 
@@ -411,7 +415,7 @@ channel_set_solo_midi_cc(
   return 0;
 }
 
-void
+int
 channel_autoset_volume_midi_cc(
   jack_mixer_channel_t channel)
 {
@@ -426,12 +430,13 @@ channel_autoset_volume_midi_cc(
 
       LOG_DEBUG("New channel \"%s\" volume mapped to CC#%i", channel_ptr->name, i);
 
-      break;
+      return i;
     }
   }
+  return -1;
 }
 
-void
+int
 channel_autoset_balance_midi_cc(
   jack_mixer_channel_t channel)
 {
@@ -446,12 +451,13 @@ channel_autoset_balance_midi_cc(
 
       LOG_DEBUG("New channel \"%s\" balance mapped to CC#%i", channel_ptr->name, i);
 
-      break;
+      return i;
     }
   }
+  return -1;
 }
 
-void
+int
 channel_autoset_mute_midi_cc(
   jack_mixer_channel_t channel)
 {
@@ -466,12 +472,13 @@ channel_autoset_mute_midi_cc(
 
       LOG_DEBUG("New channel \"%s\" mute mapped to CC#%i", channel_ptr->name, i);
 
-      break;
+      return i;
     }
   }
+  return -1;
 }
 
-void
+int
 channel_autoset_solo_midi_cc(
   jack_mixer_channel_t channel)
 {
@@ -486,9 +493,10 @@ channel_autoset_solo_midi_cc(
 
       LOG_DEBUG("New channel \"%s\" solo mapped to CC#%i", channel_ptr->name, i);
 
-      break;
+      return i;
     }
   }
+  return -1;
 }
 
 void
@@ -1316,14 +1324,18 @@ process(
       {
         continue;
       }
+
       midi_out_buffer = jack_midi_event_reserve(midi_buffer, i, 3);
+
       if (midi_out_buffer == NULL)
       {
         continue;
       }
+
       midi_out_buffer[0] = 0xB0; /* control change */
       midi_out_buffer[1] = cc_channel_index;
-      midi_out_buffer[2] = (unsigned char)(127*scale_db_to_scale(channel_ptr->midi_scale, value_to_db(channel_ptr->volume_new)));
+      midi_out_buffer[2] = (unsigned char)(127 * scale_db_to_scale(channel_ptr->midi_scale,
+                                           value_to_db(channel_ptr->volume_new)));
 
       LOG_DEBUG(
         "%u: CC#%u <- %u",

--- a/jack_mixer.h
+++ b/jack_mixer.h
@@ -200,19 +200,19 @@ void channel_set_midi_cc_volume_picked_up(jack_mixer_channel_t channel,
 void channel_set_midi_cc_balance_picked_up(jack_mixer_channel_t channel,
   bool status);
 
-void
+int
 channel_autoset_volume_midi_cc(
   jack_mixer_channel_t channel);
 
-void
+int
 channel_autoset_balance_midi_cc(
   jack_mixer_channel_t channel);
 
-void
+int
 channel_autoset_mute_midi_cc(
   jack_mixer_channel_t channel);
 
-void
+int
 channel_autoset_solo_midi_cc(
   jack_mixer_channel_t channel);
 

--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -281,25 +281,10 @@ class JackMixer(SerializedObject):
             channel = InputChannel(self, name, stereo, value)
             self.add_channel_precreated(channel)
         except Exception:
-            error_dialog(self.window, "Channel creation failed.")
+            error_dialog(self.window, "Input channel creation failed.")
             return
-        if volume_cc != -1:
-            channel.channel.volume_midi_cc = volume_cc
-        else:
-            channel.channel.autoset_volume_midi_cc()
-        if balance_cc != -1:
-            channel.channel.balance_midi_cc = balance_cc
-        else:
-            channel.channel.autoset_balance_midi_cc()
-        if mute_cc != -1:
-            channel.channel.mute_midi_cc = mute_cc
-        else:
-            channel.channel.autoset_mute_midi_cc()
-        if solo_cc != -1:
-            channel.channel.solo_midi_cc = solo_cc
-        else:
-            channel.channel.autoset_solo_midi_cc()
 
+        channel.assign_midi_ccs(volume_cc, balance_cc, mute_cc, solo_cc)
         return channel
 
     def add_channel_precreated(self, channel):
@@ -332,29 +317,17 @@ class JackMixer(SerializedObject):
         channel.connect('input-channel-order-changed', self.on_input_channel_order_changed)
 
     def add_output_channel(self, name, stereo, volume_cc, balance_cc, mute_cc,
-            display_solo_buttons, color, value):
+                           display_solo_buttons, color, value):
         try:
             channel = OutputChannel(self, name, stereo, value)
             channel.display_solo_buttons = display_solo_buttons
             channel.color = color
             self.add_output_channel_precreated(channel)
         except Exception:
-            error_dialog(self.window, "Channel creation failed")
+            error_dialog(self.window, "Output channel creation failed")
             return
 
-        if volume_cc != -1:
-            channel.channel.volume_midi_cc = volume_cc
-        else:
-            channel.channel.autoset_volume_midi_cc()
-        if balance_cc != -1:
-            channel.channel.balance_midi_cc = balance_cc
-        else:
-            channel.channel.autoset_balance_midi_cc()
-        if mute_cc != -1:
-            channel.channel.mute_midi_cc = mute_cc
-        else:
-            channel.channel.autoset_mute_midi_cc()
-
+        channel.assign_midi_ccs(volume_cc, balance_cc, mute_cc)
         return channel
 
     def add_output_channel_precreated(self, channel):

--- a/jack_mixer_c.c
+++ b/jack_mixer_c.c
@@ -586,37 +586,61 @@ Channel_remove(ChannelObject *self, PyObject *args)
 static PyObject*
 Channel_autoset_volume_midi_cc(ChannelObject *self, PyObject *args)
 {
+	unsigned int result;
 	if (! PyArg_ParseTuple(args, "")) return NULL;
-	channel_autoset_volume_midi_cc(self->channel);
-	Py_INCREF(Py_None);
-	return Py_None;
+
+	result = channel_autoset_volume_midi_cc(self->channel);
+
+	if (result < 0) {
+		PyErr_SetString(PyExc_RuntimeError, "No free CC for channel volume.");
+	}
+
+	return PyLong_FromLong(result);
 }
 
 static PyObject*
 Channel_autoset_balance_midi_cc(ChannelObject *self, PyObject *args)
 {
+	unsigned int result;
 	if (! PyArg_ParseTuple(args, "")) return NULL;
-	channel_autoset_balance_midi_cc(self->channel);
-	Py_INCREF(Py_None);
-	return Py_None;
+
+	result = channel_autoset_balance_midi_cc(self->channel);
+
+	if (result < 0) {
+		PyErr_SetString(PyExc_RuntimeError, "No free CC for channel balance.");
+	}
+
+	return PyLong_FromLong(result);
 }
 
 static PyObject*
 Channel_autoset_mute_midi_cc(ChannelObject *self, PyObject *args)
 {
+	unsigned int result;
 	if (! PyArg_ParseTuple(args, "")) return NULL;
-	channel_autoset_mute_midi_cc(self->channel);
-	Py_INCREF(Py_None);
-	return Py_None;
+
+	result = channel_autoset_mute_midi_cc(self->channel);
+
+	if (result < 0) {
+		PyErr_SetString(PyExc_RuntimeError, "No free CC for channel mute.");
+	}
+
+	return PyLong_FromLong(result);
 }
 
 static PyObject*
 Channel_autoset_solo_midi_cc(ChannelObject *self, PyObject *args)
 {
+	unsigned int result;
 	if (! PyArg_ParseTuple(args, "")) return NULL;
-	channel_autoset_solo_midi_cc(self->channel);
-	Py_INCREF(Py_None);
-	return Py_None;
+
+	result = channel_autoset_solo_midi_cc(self->channel);
+
+	if (result < 0) {
+		PyErr_SetString(PyExc_RuntimeError, "No free CC channel solo.");
+	}
+
+	return PyLong_FromLong(result);
 }
 
 static PyMethodDef channel_methods[] = {
@@ -1000,7 +1024,7 @@ Mixer_set_midi_behavior_mode(MixerObject *self, PyObject *value, void *closure)
 {
 	int mode;
 	unsigned int result;
-	
+
 	mode = PyLong_AsLong(value);
 	result = set_midi_behavior_mode(self->mixer, mode);
 	if (result == 0) {
@@ -1146,10 +1170,10 @@ PyMODINIT_FUNC PyInit_jack_mixer_c(void)
 		return NULL;
 	if (PyType_Ready(&ScaleType) < 0)
 		return NULL;
-		
+
 	m = PyModule_Create(&moduledef);
 	//m = Py_InitModule3("jack_mixer_c", jack_mixer_methods, "module doc");
-	
+
 	Py_INCREF(&MixerType);
 	PyModule_AddObject(m, "Mixer", (PyObject*)&MixerType);
 	Py_INCREF(&ChannelType);
@@ -1158,7 +1182,7 @@ PyMODINIT_FUNC PyInit_jack_mixer_c(void)
 	PyModule_AddObject(m, "OutputChannel", (PyObject*)&OutputChannelType);
 	Py_INCREF(&ScaleType);
 	PyModule_AddObject(m, "Scale", (PyObject*)&ScaleType);
-	
+
 	return m;
 }
 


### PR DESCRIPTION
Refactor / clean-up `channel` module:

* Clean-up class hierarchy
* Use `super()` were appropriate
* Reduce DRY by moving shared code into super class
* Re-use channel property dialog instances
* Update old property syntax
* Change class attributes into instance attributes where appropriate
* Upper-case constant global constant name    
* Module level code re-ordering
* Re-order `Channel` class methods into sections
* Some code reformating / refactoring to keep line length under 100 chars

Refactor / clean-up `jack_mixer` module:
    
* Move helper methods to inlined functions
* Change class attributes into instance attributes where appropriate
* Re-order `JackMixer` class methods into sections
* Some code reformatting to keep line-length under 100 chars
* Updated copyright notice in file header comment

Refactor / improve MIDI CC auto-assignment:

* `autoset_*_midi_cc` functions return assigned CC number
* Move MIDI CC assignment into `Channel` class
* Unify code to handle both input and output channels and log errors and successful assignments
* Some minor C-code reformatting
    

