### PR TITLE
Add --disable-gui configure option to allow buidling only jack_mix_box

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,18 +17,13 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+jack_mixerdir = $(pkgdatadir)
+
 AM_CFLAGS = $(JACKMIXER_CFLAGS) -D_GNU_SOURCE -Wall -fno-strict-aliasing
 if DEV_VERSION
 AM_CFLAGS +=  -Werror
 endif
 
-SUBDIRS = data
-
-AM_CPPFLAGS = $(PYTHON_INCLUDES)
-
-jack_mixerdir = $(pkgdatadir)
-pkgpyexecdir = $(pythondir)
-pkgpyexec_LTLIBRARIES = jack_mixer_c.la
 
 jack_mixer_c_la_LDFLAGS = -module -avoid-version
 
@@ -37,6 +32,29 @@ jack_mixer_c_la_LIBADD = $(JACKMIXER_LIBS)
 jack_mixer_c_la_SOURCES = \
 	jack_mixer.c jack_mixer.h list.h log.h log.c scale.c scale.h jack_compat.h \
 	jack_mixer_c.c
+
+EXTRA_DIST = COPYING NEWS
+
+bin_PROGRAMS = jack_mix_box
+
+
+jack_mix_box_SOURCES = jack_mix_box.c jack_mixer.c scale.c log.c
+
+jack_mix_box_CFLAGS = $(JACKMIXER_CFLAGS)
+
+jack_mix_box_LDADD = $(JACKMIXER_LIBS) -lm
+
+
+
+
+if ENABLE_GUI
+
+SUBDIRS = data
+
+AM_CPPFLAGS = $(PYTHON_INCLUDES)
+
+pkgpyexecdir = $(pythondir)
+pkgpyexec_LTLIBRARIES = jack_mixer_c.la
 
 dist_jack_mixer_DATA = \
 	abspeak.py \
@@ -52,20 +70,13 @@ dist_jack_mixer_DATA = \
 	version.py
 
 CLEANFILES = *.pyc
-EXTRA_DIST = test.py COPYING jack_mixer.py NEWS
+EXTRA_DIST += test.py jack_mixer.py 
 
 bin_SCRIPTS = $(srcdir)/jack_mixer.py
 
-bin_PROGRAMS = jack_mix_box
 
 jack_mixer_c.so: jack_mixer_c.la
 	ln -nfs .libs/jack_mixer_c.so
-
-jack_mix_box_SOURCES = jack_mix_box.c jack_mixer.c scale.c log.c
-
-jack_mix_box_CFLAGS = $(JACKMIXER_CFLAGS)
-
-jack_mix_box_LDADD = $(JACKMIXER_LIBS) -lm
 
 test: _jack_mixer_c.so
 	@./test.py
@@ -78,3 +89,5 @@ pacoinstall:
 	-paco -rvB jack_mixer
 	-paco -lE `pwd` -E /etc -p jack_mixer-`svnversion` "make install"
 	-paco -i jack_mixer
+
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -71,20 +71,28 @@ then
 fi
 
 # Python checking
-AM_PATH_PYTHON(3.5)
-AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(Could not find Python headers)])
-#AS_AC_EXPAND(PYTHONDIR, $pythondir)
-#AC_SUBST(PYTHONDIR)
-
+AC_ARG_ENABLE(gui, [AS_HELP_STRING(--disable-gui, [Disable GUI [default=no]])])
 AC_ARG_ENABLE(pymod-checks, [AS_HELP_STRING(--disable-pymod-checks, [Force disable checks for Python modules required at run time])], [ disable_pymod_checks="yes" ], [ disable_pymod_checks="no" ])
-
-if test "$disable_pymod_checks" != "yes"
+if test "$enable_gui" != "no"
 then
-  AM_CHECK_PYMOD(gi,,,[AC_MSG_ERROR(Could not find Pygi)])
-  AM_CHECK_PYMOD(cairo,,,[AC_MSG_ERROR(Could not find Pycairo)])
+  AM_PATH_PYTHON(3.5)
+  AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(Could not find Python headers)])
+  #AS_AC_EXPAND(PYTHONDIR, $pythondir)
+  #AC_SUBST(PYTHONDIR)
+
+
+  if test "$disable_pymod_checks" != "yes"
+  then
+    AM_CHECK_PYMOD(gi,,,[AC_MSG_ERROR(Could not find Pygi)])
+    AM_CHECK_PYMOD(cairo,,,[AC_MSG_ERROR(Could not find Pycairo)])
+  else
+    AC_MSG_WARN([Checks for python modules required runtime have been force disabled])
+  fi
 else
-  AC_MSG_WARN([Checks for python modules required runtime have been force disabled])
+  AC_MSG_WARN([GUI has been force disabled. Only jack_mix_box cli application will be built.])
 fi
+
+AM_CONDITIONAL(ENABLE_GUI, [test x$enable_gui != xno])
 
 AC_OUTPUT([
 Makefile
@@ -92,12 +100,14 @@ data/Makefile
 data/art/Makefile
 ])
 
+
 AC_MSG_RESULT([])
 AC_MSG_RESULT([**********************************************************************])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([Prefix:            $prefix])
 AC_MSG_RESULT([Python dir:        $pythondir])
 AC_MSG_RESULT([])
+AC_MSG_RESULT([GUI  support:      $enable_gui])
 AC_MSG_RESULT([MIDI support:      $have_jackmidi])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([**********************************************************************])

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,7 @@ then
   AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(Could not find Python headers)])
   #AS_AC_EXPAND(PYTHONDIR, $pythondir)
   #AC_SUBST(PYTHONDIR)
-
+  enable_gui="yes"
 
   if test "$disable_pymod_checks" != "yes"
   then


### PR DESCRIPTION
Took care of autotools side of jack_mixer, to be able to build only the jack_mix_box if somebody requires just a headless C mixer application.
To configure the headless build one has to pass the "--disable-gui" cli argument during configuration, in which case python is no longer a requirement.
This takes care of feature request ticket #51 