### PR TITLE
Re-organize CSS styling and set distinctive colors for active toggle buttons

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ dist_jack_mixer_DATA = \
 	serialization.py \
 	serialization_xml.py \
 	slider.py \
+	styling.py \
 	version.py
 
 CLEANFILES = *.pyc

--- a/abspeak.py
+++ b/abspeak.py
@@ -22,22 +22,6 @@ from gi.repository import Gdk
 from gi.repository import GObject
 
 
-CSS = b"""
-.over_zero {
-    background-color: #cc4c00;
-}
-
-.is_nan {
-    background-color: #b20000;
-}
-"""
-css_provider = Gtk.CssProvider()
-css_provider.load_from_data(CSS)
-context = Gtk.StyleContext()
-screen = Gdk.Screen.get_default()
-context.add_provider_for_screen(screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-
-
 class AbspeakWidget(Gtk.EventBox):
     def __init__(self):
         super().__init__()

--- a/gui.py
+++ b/gui.py
@@ -19,7 +19,7 @@ import configparser
 import logging
 import os
 
-import gi
+import gi  # noqa:F401
 from gi.repository import GObject
 from serialization import SerializedObject
 

--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -29,7 +29,6 @@ from argparse import ArgumentParser
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-from gi.repository import GObject
 from gi.repository import GLib
 
 # temporary change Python modules lookup path to look into installation
@@ -41,10 +40,11 @@ import jack_mixer_c
 
 import gui
 import scale
-from channel import *
+from channel import InputChannel, NewInputChannelDialog, NewOutputChannelDialog, OutputChannel
 from nsmclient import NSMClient
 from serialization_xml import XmlSerialization
 from serialization import SerializedObject, Serializator
+from styling import load_css_styles
 from preferences import PreferencesDialog
 from version import __version__
 
@@ -150,6 +150,7 @@ class JackMixer(SerializedObject):
     def create_ui(self, with_nsm):
         self.channels = []
         self.output_channels = []
+        load_css_styles()
         self.window = Gtk.Window(type=Gtk.WindowType.TOPLEVEL)
         self.window.set_icon_name('jack_mixer')
         self.gui_factory = gui.Factory(self.window, self.meter_scales, self.slider_scales)

--- a/serialization_xml.py
+++ b/serialization_xml.py
@@ -15,9 +15,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from serialization import *
 import xml.dom
 import xml.dom.minidom
+
+from serialization import SerializationBackend
+
 
 class XmlSerialization(SerializationBackend):
     def get_root_serialization_object(self, name):
@@ -39,6 +41,7 @@ class XmlSerialization(SerializationBackend):
 
     def load(self, file):
         self.doc = xml.dom.minidom.parse(file)
+
 
 class XmlSerializationObject:
     def __init__(self, doc, element):

--- a/styling.py
+++ b/styling.py
@@ -1,0 +1,209 @@
+# This file is part of jack_mixer
+#
+# Copyright (C) 2006-2009 Nedko Arnaudov <nedko@arnaudov.name>
+# Copyright (C) 2009-2020 Frederic Peters <fpeters@0d.be> et al.
+# Copyright (C) 2020 Christopher Arndt <info@chrisarndt>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from random import random
+
+import gi  # noqa:F401
+from gi.repository import Gtk
+from gi.repository import Gdk
+
+
+# CSS widget styling
+DEFAULT_CSS = """\
+/* Global color definitions */
+
+@define-color monitor_bgcolor_hover #C0BFBC;
+@define-color monitor_bgcolor_checked #9A9996;
+@define-color mute_bgcolor_hover #FFBC80;
+@define-color mute_bgcolor_checked #FF7800;
+@define-color solo_bgcolor_hover #76A28E;
+@define-color solo_bgcolor_checked #26A269;
+@define-color prefader_bgcolor_hover #A6C2E4;
+@define-color prefader_bgcolor_checked #3584E4;
+
+
+/* Channel strips */
+
+.top_label {
+    padding: 0px .1em;
+    min-height: 1.5rem;
+}
+
+.wide {
+    font-size: medium;
+}
+
+.narrow {
+    font-size: smaller;
+}
+
+.vbox_fader {
+    border: 1px inset #111;
+}
+
+.readout {
+    font-size: 80%;
+    margin: .1em;
+    padding: 0;
+    border: 1px inset #111;
+    color: white;
+    background-color: #333;
+    background-image: none;
+}
+
+
+/* Channel buttons */
+
+button {
+    padding: 0px;
+}
+button.monitor:hover,
+button.mute:hover,
+button.solo:hover,
+button.monitor:checked,
+button.mute:checked,
+button.solo:checked {
+    color: white;
+    text-shadow: unset;
+    background-image: none;
+}
+button.monitor:hover {
+    background-color: @monitor_bgcolor_hover;
+}
+button.monitor:checked {
+    background-color: @monitor_bgcolor_checked;
+}
+button.mute:hover {
+    background-color: @mute_bgcolor_hover;
+}
+button.mute:checked {
+    background-color: @mute_bgcolor_checked;
+}
+button.solo:hover {
+    background-color: @solo_bgcolor_hover;
+}
+button.solo:checked {
+    background-color: @solo_bgcolor_checked;
+}
+
+
+/* Control groups */
+
+.control_group {
+    min-width: 0px;
+    padding: 0px;
+}
+
+.control_group .label,
+.control_group .mute,
+.control_group .pre_fader,
+.control_group .solo {
+    font-size: smaller;
+    padding: 0px .1em;
+}
+
+.control_group .mute:hover,
+.control_group .solo:hover,
+.control_group .prefader:hover,
+.control_group .mute:checked,
+.control_group .solo:checked,
+.control_group .prefader:checked {
+    color: white;
+    text-shadow: unset;
+    background-image: none;
+}
+.control_group .mute:hover {
+    background-color: @mute_bgcolor_hover;
+}
+.control_group .mute:checked {
+    background-color:@mute_bgcolor_checked;
+}
+.control_group .solo:hover {
+    background-color: @solo_bgcolor_hover;
+}
+.control_group .solo:checked {
+    background-color: @solo_bgcolor_checked;
+}
+.control_group .prefader:hover {
+    background-color: @prefader_bgcolor_hover;
+}
+.control_group .prefader:checked {
+    background-color: @prefader_bgcolor_checked;
+}
+
+
+/* Peak meters */
+
+.over_zero {
+    background-color: #cc4c00;
+}
+
+.is_nan {
+    background-color: #b20000;
+}
+"""
+
+COLOR_TMPL_CSS = """\
+.{} {{
+    background-color: {};
+    color: {};
+}}
+"""
+
+
+def add_css_provider(css, priority=Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION):
+    css_provider = Gtk.CssProvider()
+    css_provider.load_from_data(css.encode("utf-8"))
+    context = Gtk.StyleContext()
+    screen = Gdk.Screen.get_default()
+    context.add_provider_for_screen(screen, css_provider, priority)
+
+
+def get_text_color(background_color):
+    """Calculate the luminance of the given color (GdkRGBA)
+    and return an appropriate text color."""
+    # luminance coefficients taken from section C-9 from
+    # http://www.faqs.org/faqs/graphics/colorspace-faq/
+    brightess = (
+        background_color.red * 0.212671
+        + background_color.green * 0.715160
+        + background_color.blue * 0.072169
+    )
+
+    if brightess > 0.5:
+        return "black"
+    else:
+        return "white"
+
+
+def load_css_styles():
+    add_css_provider(DEFAULT_CSS)
+
+
+def set_background_color(widget, name, color):
+    color_string = color.to_string()
+    add_css_provider(
+        COLOR_TMPL_CSS.format(name, color_string, get_text_color(color))
+    )
+    widget_context = widget.get_style_context()
+    widget_context.add_class(name)
+
+
+def random_color():
+    return Gdk.RGBA(random(), random(), random(), 1)


### PR DESCRIPTION
* Move all CSS styles and styling related functions into a new `styling` module.
* Provide helper function to add CSS provider in this module.
* Load default CSS in `JackMixer.create_ui()` using the above function (user CSS files will probably be added in another PR).
* Use CSS classes instead of widget names for channel strip elements (buttons etc.).
* Set background color of toggle buttons in channel strips when hovered or active to more distinct colors.

Fixes: #85