### PR TITLE
Re-format all Python code with black

### DIFF
--- a/abspeak.py
+++ b/abspeak.py
@@ -37,15 +37,15 @@ class AbspeakWidget(Gtk.EventBox):
         if event.type == Gdk.EventType.BUTTON_PRESS:
             if event.button == 1 or event.button == 2 or event.button == 3:
                 context = self.get_style_context()
-                context.remove_class('over_zero')
-                context.remove_class('is_nan')
+                context.remove_class("over_zero")
+                context.remove_class("is_nan")
 
             if event.button == 1 or event.button == 3:
                 self.emit("reset")
             elif event.button == 2:
                 adjust = -self.peak
 
-                if abs(adjust) < 30:    # we better don't adjust more than +- 30 dB
+                if abs(adjust) < 30:  # we better don't adjust more than +- 30 dB
                     self.emit("volume-adjust", adjust)
 
     def set_peak(self, peak):
@@ -53,21 +53,26 @@ class AbspeakWidget(Gtk.EventBox):
         context = self.get_style_context()
 
         if math.isnan(peak):
-            context.remove_class('over_zero')
-            context.add_class('is_nan')
+            context.remove_class("over_zero")
+            context.add_class("is_nan")
             self.label.set_text("NaN")
         else:
             text = "%+.1f" % peak
-            context.remove_class('is_nan')
+            context.remove_class("is_nan")
 
             if peak > 0:
-                context.add_class('over_zero')
+                context.add_class("over_zero")
 
             self.label.set_text(text)
 
 
-GObject.signal_new("reset", AbspeakWidget,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None, [])
-GObject.signal_new("volume-adjust", AbspeakWidget,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None,
-                   [GObject.TYPE_FLOAT])
+GObject.signal_new(
+    "reset", AbspeakWidget, GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None, []
+)
+GObject.signal_new(
+    "volume-adjust",
+    AbspeakWidget,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [GObject.TYPE_FLOAT],
+)

--- a/channel.py
+++ b/channel.py
@@ -36,11 +36,11 @@ BUTTON_PADDING = 1
 
 class Channel(Gtk.Box, SerializedObject):
     """Widget with slider and meter used as base class for more specific
-       channel widgets"""
+    channel widgets"""
 
     num_instances = 0
 
-    def __init__(self, app, name, stereo, value = None):
+    def __init__(self, app, name, stereo, value=None):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.app = app
         self.mixer = app.mixer
@@ -108,15 +108,15 @@ class Channel(Gtk.Box, SerializedObject):
 
         self.pack_start(self.hbox_mutesolo, False, False, 0)
 
-        self.monitor_button = Gtk.ToggleButton('MON')
+        self.monitor_button = Gtk.ToggleButton("MON")
         self.monitor_button.get_style_context().add_class("monitor")
-        self.monitor_button.connect('toggled', self.on_monitor_button_toggled)
+        self.monitor_button.connect("toggled", self.on_monitor_button_toggled)
         self.pack_start(self.monitor_button, False, False, 0)
 
     def create_fader(self):
         # HBox for fader and meter
         self.vbox_fader = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.vbox_fader.get_style_context().add_class('vbox_fader')
+        self.vbox_fader.get_style_context().add_class("vbox_fader")
 
         self.hbox_readouts = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.hbox_readouts.set_homogeneous(True)
@@ -159,13 +159,14 @@ class Channel(Gtk.Box, SerializedObject):
         self.vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.pack_start(self.vbox, False, True, 0)
         self.label_name = Gtk.Label()
-        self.label_name.get_style_context().add_class('top_label')
+        self.label_name.get_style_context().add_class("top_label")
         self.label_name.set_text(self.channel_name)
-        self.label_name.set_max_width_chars(self.label_chars_wide if self.wide else
-                                            self.label_chars_narrow)
+        self.label_name.set_max_width_chars(
+            self.label_chars_wide if self.wide else self.label_chars_narrow
+        )
         self.label_name.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         self.label_name_event_box = Gtk.EventBox()
-        self.label_name_event_box.connect('button-press-event', self.on_label_mouse)
+        self.label_name_event_box.connect("button-press-event", self.on_label_mouse)
         self.label_name_event_box.add(self.label_name)
 
         # Volume fader
@@ -177,16 +178,16 @@ class Channel(Gtk.Box, SerializedObject):
         self.volume_digits = Gtk.Entry()
         self.volume_digits.set_has_frame(False)
         self.volume_digits.set_width_chars(5)
-        self.volume_digits.set_property('xalign', 0.5)
+        self.volume_digits.set_property("xalign", 0.5)
         self.volume_digits.connect("key-press-event", self.on_volume_digits_key_pressed)
         self.volume_digits.connect("focus-out-event", self.on_volume_digits_focus_out)
-        self.volume_digits.get_style_context().add_class('readout')
+        self.volume_digits.get_style_context().add_class("readout")
 
         # Peak level label
         self.abspeak = abspeak.AbspeakWidget()
         self.abspeak.connect("reset", self.on_abspeak_reset)
         self.abspeak.connect("volume-adjust", self.on_abspeak_adjust)
-        self.abspeak.get_style_context().add_class('readout')
+        self.abspeak.get_style_context().add_class("readout")
 
         # Level meter
         if self.stereo:
@@ -203,30 +204,29 @@ class Channel(Gtk.Box, SerializedObject):
             else:
                 self.slider_adjustment.set_value_db(0)
 
-        self.slider_adjustment.connect("volume-changed",
-                                       self.on_volume_changed)
-        self.slider_adjustment.connect("volume-changed-from-midi",
-                                       self.on_volume_changed_from_midi)
-        self.balance_adjustment.connect("balance-changed",
-                                        self.on_balance_changed)
+        self.slider_adjustment.connect("volume-changed", self.on_volume_changed)
+        self.slider_adjustment.connect(
+            "volume-changed-from-midi", self.on_volume_changed_from_midi
+        )
+        self.balance_adjustment.connect("balance-changed", self.on_balance_changed)
 
-        self.gui_factory.connect("default-meter-scale-changed",
-                                 self.on_default_meter_scale_changed)
-        self.gui_factory.connect("default-slider-scale-changed",
-                                 self.on_default_slider_scale_changed)
-        self.gui_factory.connect('vumeter-color-changed',
-                                 self.on_vumeter_color_changed)
-        self.gui_factory.connect('vumeter-color-scheme-changed',
-                                 self.on_vumeter_color_changed)
-        self.gui_factory.connect('use-custom-widgets-changed',
-                                 self.on_custom_widgets_changed)
+        self.gui_factory.connect(
+            "default-meter-scale-changed", self.on_default_meter_scale_changed
+        )
+        self.gui_factory.connect(
+            "default-slider-scale-changed", self.on_default_slider_scale_changed
+        )
+        self.gui_factory.connect("vumeter-color-changed", self.on_vumeter_color_changed)
+        self.gui_factory.connect("vumeter-color-scheme-changed", self.on_vumeter_color_changed)
+        self.gui_factory.connect("use-custom-widgets-changed", self.on_custom_widgets_changed)
 
         self.connect("key-press-event", self.on_key_pressed)
         self.connect("scroll-event", self.on_scroll)
 
         entries = [Gtk.TargetEntry.new(self.__class__.__name__, Gtk.TargetFlags.SAME_APP, 0)]
-        self.label_name_event_box.drag_source_set(Gdk.ModifierType.BUTTON1_MASK, entries,
-                Gdk.DragAction.MOVE)
+        self.label_name_event_box.drag_source_set(
+            Gdk.ModifierType.BUTTON1_MASK, entries, Gdk.DragAction.MOVE
+        )
         self.label_name_event_box.connect("drag-data-get", self.on_drag_data_get)
         self.drag_dest_set(Gtk.DestDefaults.ALL, entries, Gdk.DragAction.MOVE)
         self.connect_after("drag-data-received", self.on_drag_data_received)
@@ -244,9 +244,11 @@ class Channel(Gtk.Box, SerializedObject):
             if event.button == 1:
                 self.on_channel_properties()
             return True
-        elif (event.state & Gdk.ModifierType.CONTROL_MASK and
-              event.type == Gdk.EventType.BUTTON_PRESS and
-              event.button == 1):
+        elif (
+            event.state & Gdk.ModifierType.CONTROL_MASK
+            and event.type == Gdk.EventType.BUTTON_PRESS
+            and event.button == 1
+        ):
             if self.wide:
                 self.narrow()
             else:
@@ -272,7 +274,7 @@ class Channel(Gtk.Box, SerializedObject):
     def on_vumeter_color_changed(self, gui_factory, *args):
         color = gui_factory.get_vumeter_color()
         color_scheme = gui_factory.get_vumeter_color_scheme()
-        if color_scheme != 'solid':
+        if color_scheme != "solid":
             self.meter.set_color(None)
         else:
             self.meter.set_color(Gdk.color_parse(color))
@@ -287,14 +289,14 @@ class Channel(Gtk.Box, SerializedObject):
         self.slider_adjustment.set_value_db(self.slider_adjustment.get_value_db() + adjust)
         self.channel.abspeak = None
         # We want to update gui even if actual decibels have not changed (scale wrap for example)
-        #self.update_volume(False)
+        # self.update_volume(False)
 
     def on_abspeak_reset(self, abspeak):
         log.debug("abspeak reset")
         self.channel.abspeak = None
 
     def on_volume_digits_key_pressed(self, widget, event):
-        if (event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter):
+        if event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter:
             db_text = self.volume_digits.get_text()
             try:
                 db = float(db_text)
@@ -304,10 +306,10 @@ class Channel(Gtk.Box, SerializedObject):
                 self.update_volume(False)
                 return
             self.slider_adjustment.set_value_db(db)
-            #self.grab_focus()
+            # self.grab_focus()
             # We want to update gui even if actual decibels have not changed
             # (scale wrap for example)
-            #self.update_volume(False)
+            # self.update_volume(False)
 
     def on_volume_digits_focus_out(self, widget, event):
         log.debug("Volume digits focus out detected.")
@@ -324,7 +326,7 @@ class Channel(Gtk.Box, SerializedObject):
         self.update_volume(True)
 
     def on_volume_changed_from_midi(self, adjustment):
-        self.update_volume(True, from_midi = True)
+        self.update_volume(True, from_midi=True)
 
     def on_balance_changed(self, adjustment):
         balance = self.balance_adjustment.get_value()
@@ -333,28 +335,27 @@ class Channel(Gtk.Box, SerializedObject):
         self.app.update_monitor(self)
 
     def on_key_pressed(self, widget, event):
-        if (event.keyval == Gdk.KEY_Up):
+        if event.keyval == Gdk.KEY_Up:
             log.debug(self.channel_name + " Up")
             self.slider_adjustment.step_up()
             return True
-        elif (event.keyval == Gdk.KEY_Down):
+        elif event.keyval == Gdk.KEY_Down:
             log.debug(self.channel_name + " Down")
             self.slider_adjustment.step_down()
             return True
 
         return False
 
-
     def on_drag_data_get(self, widget, drag_context, data, info, time):
         channel = widget.get_parent().get_parent()
-        data.set(data.get_target(), 8, channel._channel_name.encode('utf-8'))
+        data.set(data.get_target(), 8, channel._channel_name.encode("utf-8"))
 
     def on_drag_data_received(self, widget, drag_context, x, y, data, info, time):
         pass
 
     def on_midi_event_received(self, *args):
-        self.slider_adjustment.set_value_db(self.channel.volume, from_midi = True)
-        self.balance_adjustment.set_balance(self.channel.balance, from_midi = True)
+        self.slider_adjustment.set_value_db(self.channel.volume, from_midi=True)
+        self.balance_adjustment.set_balance(self.channel.balance, from_midi=True)
 
     def on_mute_toggled(self, button):
         self.channel.out_mute = self.mute.get_active()
@@ -363,11 +364,11 @@ class Channel(Gtk.Box, SerializedObject):
         if button.get_active():
             for channel in self.app.channels + self.app.output_channels:
                 if channel.monitor_button.get_active() and channel.monitor_button is not button:
-                    channel.monitor_button.handler_block_by_func(
-                                channel.on_monitor_button_toggled)
+                    channel.monitor_button.handler_block_by_func(channel.on_monitor_button_toggled)
                     channel.monitor_button.set_active(False)
                     channel.monitor_button.handler_unblock_by_func(
-                                channel.on_monitor_button_toggled)
+                        channel.on_monitor_button_toggled
+                    )
             self.app.set_monitored_channel(self)
         else:
             if self.app._monitored_channel.channel.name == self.channel.name:
@@ -434,11 +435,11 @@ class Channel(Gtk.Box, SerializedObject):
         ctx = self.label_name.get_style_context()
 
         if flag:
-            ctx.remove_class('narrow')
-            ctx.add_class('wide')
+            ctx.remove_class("narrow")
+            ctx.add_class("wide")
         else:
-            ctx.remove_class('wide')
-            ctx.add_class('narrow')
+            ctx.remove_class("wide")
+            ctx.add_class("narrow")
 
         label = self.label_name.get_label()
         label_width = self.label_chars_wide if flag else self.label_chars_narrow
@@ -449,7 +450,8 @@ class Channel(Gtk.Box, SerializedObject):
 
         self.meter.widen(flag)
         self.hbox_readouts.set_orientation(
-            Gtk.Orientation.HORIZONTAL if flag else Gtk.Orientation.VERTICAL)
+            Gtk.Orientation.HORIZONTAL if flag else Gtk.Orientation.VERTICAL
+        )
 
     def narrow(self):
         self.widen(False)
@@ -466,7 +468,7 @@ class Channel(Gtk.Box, SerializedObject):
 
         self.abspeak.set_peak(self.channel.abspeak)
 
-    def update_volume(self, update_engine, from_midi = False):
+    def update_volume(self, update_engine, from_midi=False):
         db = self.slider_adjustment.get_value_db()
 
         db_text = "%.2f" % db
@@ -485,16 +487,16 @@ class Channel(Gtk.Box, SerializedObject):
         object_backend.add_property("balance", "%f" % self.balance_adjustment.get_value())
         object_backend.add_property("wide", "%s" % str(self.wide))
 
-        if hasattr(self.channel, 'out_mute'):
-            object_backend.add_property('out_mute', str(self.channel.out_mute))
+        if hasattr(self.channel, "out_mute"):
+            object_backend.add_property("out_mute", str(self.channel.out_mute))
         if self.channel.volume_midi_cc != -1:
-            object_backend.add_property('volume_midi_cc', str(self.channel.volume_midi_cc))
+            object_backend.add_property("volume_midi_cc", str(self.channel.volume_midi_cc))
         if self.channel.balance_midi_cc != -1:
-            object_backend.add_property('balance_midi_cc', str(self.channel.balance_midi_cc))
+            object_backend.add_property("balance_midi_cc", str(self.channel.balance_midi_cc))
         if self.channel.mute_midi_cc != -1:
-            object_backend.add_property('mute_midi_cc', str(self.channel.mute_midi_cc))
+            object_backend.add_property("mute_midi_cc", str(self.channel.mute_midi_cc))
         if self.channel.solo_midi_cc != -1:
-            object_backend.add_property('solo_midi_cc', str(self.channel.solo_midi_cc))
+            object_backend.add_property("solo_midi_cc", str(self.channel.solo_midi_cc))
 
     def unserialize_property(self, name, value):
         if name == "volume":
@@ -503,19 +505,19 @@ class Channel(Gtk.Box, SerializedObject):
         if name == "balance":
             self.balance_adjustment.set_value(float(value))
             return True
-        if name == 'out_mute':
-            self.future_out_mute = (value == 'True')
+        if name == "out_mute":
+            self.future_out_mute = value == "True"
             return True
-        if name == 'volume_midi_cc':
+        if name == "volume_midi_cc":
             self.future_volume_midi_cc = int(value)
             return True
-        if name == 'balance_midi_cc':
+        if name == "balance_midi_cc":
             self.future_balance_midi_cc = int(value)
             return True
-        if name == 'mute_midi_cc':
+        if name == "mute_midi_cc":
             self.future_mute_midi_cc = int(value)
             return True
-        if name == 'solo_midi_cc':
+        if name == "solo_midi_cc":
             self.future_solo_midi_cc = int(value)
             return True
         if name == "wide":
@@ -587,7 +589,7 @@ class InputChannel(Channel):
             cg.widen()
 
     def on_drag_data_received(self, widget, drag_context, x, y, data, info, time):
-        source_name = data.get_data().decode('utf-8')
+        source_name = data.get_data().decode("utf-8")
         if source_name == self._channel_name:
             return
         self.emit("input-channel-order-changed", source_name, self._channel_name)
@@ -633,15 +635,15 @@ class InputChannel(Channel):
     def on_solo_button_pressed(self, button, event, *args):
         if event.button == 3:
             # right click on the solo button, act on all output channels
-            if button.get_active(): # was soloed
+            if button.get_active():  # was soloed
                 button.set_active(False)
-                if hasattr(button, 'touched_channels'):
+                if hasattr(button, "touched_channels"):
                     touched_channels = button.touched_channels
                     for chan in touched_channels:
                         ctlgroup = self.get_control_group(chan)
                         ctlgroup.solo.set_active(False)
                     del button.touched_channels
-            else: # was not soloed
+            else:  # was not soloed
                 button.set_active(True)
                 touched_channels = []
                 for chan in self.app.output_channels:
@@ -655,7 +657,7 @@ class InputChannel(Channel):
 
     @classmethod
     def serialization_name(cls):
-        return 'input_channel'
+        return "input_channel"
 
     def serialize(self, object_backend):
         object_backend.add_property("name", self.channel_name)
@@ -754,7 +756,7 @@ class OutputChannel(Channel):
         self.channel = None
 
     def on_drag_data_received(self, widget, drag_context, x, y, data, info, time):
-        source_name = data.get_data().decode('utf-8')
+        source_name = data.get_data().decode("utf-8")
         if source_name == self._channel_name:
             return
         self.emit("output-channel-order-changed", source_name, self._channel_name)
@@ -766,7 +768,7 @@ class OutputChannel(Channel):
 
     @classmethod
     def serialization_name(cls):
-        return 'output_channel'
+        return "output_channel"
 
     def serialize(self, object_backend):
         object_backend.add_property("name", self.channel_name)
@@ -787,14 +789,17 @@ class OutputChannel(Channel):
             if self.channel.is_in_prefader(input_channel.channel):
                 prefader_in_channels.append(input_channel)
         if muted_channels:
-            object_backend.add_property('muted_channels',
-                                        '|'.join([x.channel.name for x in muted_channels]))
+            object_backend.add_property(
+                "muted_channels", "|".join([x.channel.name for x in muted_channels])
+            )
         if solo_channels:
-            object_backend.add_property('solo_channels',
-                                        '|'.join([x.channel.name for x in solo_channels]))
+            object_backend.add_property(
+                "solo_channels", "|".join([x.channel.name for x in solo_channels])
+            )
         if prefader_in_channels:
-            object_backend.add_property('prefader_channels',
-                                        '|'.join([x.channel.name for x in prefader_in_channels]))
+            object_backend.add_property(
+                "prefader_channels", "|".join([x.channel.name for x in prefader_in_channels])
+            )
         object_backend.add_property("color", self.color.to_string())
         super().serialize(object_backend)
 
@@ -813,16 +818,16 @@ class OutputChannel(Channel):
             if value == "true":
                 self.display_solo_buttons = True
                 return True
-        if name == 'muted_channels':
-            self._init_muted_channels = value.split('|')
+        if name == "muted_channels":
+            self._init_muted_channels = value.split("|")
             return True
-        if name == 'solo_channels':
-            self._init_solo_channels = value.split('|')
+        if name == "solo_channels":
+            self._init_solo_channels = value.split("|")
             return True
-        if name == 'prefader_channels':
-            self._init_prefader_channels = value.split('|')
+        if name == "prefader_channels":
+            self._init_prefader_channels = value.split("|")
             return True
-        if name == 'color':
+        if name == "color":
             c = Gdk.RGBA()
             c.parse(value)
             self.color = c
@@ -854,13 +859,13 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         self.ok_button = self.add_button(Gtk.STOCK_APPLY, Gtk.ResponseType.APPLY)
         self.set_default_response(Gtk.ResponseType.APPLY)
 
-        self.connect('response', self.on_response_cb)
-        self.connect('delete-event', self.on_response_cb)
+        self.connect("response", self.on_response_cb)
+        self.connect("delete-event", self.on_response_cb)
 
     def create_frame(self, label, child, padding=8):
         # need to pass an empty label, otherwise no label widget is created
-        frame = Gtk.Frame(label='')
-        frame.get_label_widget().set_markup('<b>%s</b>' % label)
+        frame = Gtk.Frame(label="")
+        frame.get_label_widget().set_markup("<b>%s</b>" % label)
         frame.set_border_width(3)
         frame.set_shadow_type(Gtk.ShadowType.NONE)
 
@@ -876,81 +881,78 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         vbox = self.get_content_area()
 
         self.properties_grid = grid = Gtk.Grid()
-        vbox.pack_start(self.create_frame('Properties', grid), True, True, 0)
+        vbox.pack_start(self.create_frame("Properties", grid), True, True, 0)
         grid.set_row_spacing(8)
         grid.set_column_spacing(8)
         grid.set_column_homogeneous(True)
 
-        name_label = Gtk.Label.new_with_mnemonic('_Name')
+        name_label = Gtk.Label.new_with_mnemonic("_Name")
         name_label.set_halign(Gtk.Align.START)
         grid.attach(name_label, 0, 0, 1, 1)
         self.entry_name = Gtk.Entry()
         self.entry_name.set_activates_default(True)
-        self.entry_name.connect('changed', self.on_entry_name_changed)
+        self.entry_name.connect("changed", self.on_entry_name_changed)
         name_label.set_mnemonic_widget(self.entry_name)
         grid.attach(self.entry_name, 1, 0, 2, 1)
 
-        grid.attach(Gtk.Label(label='Mode', halign=Gtk.Align.START), 0, 1, 1, 1)
-        self.mono = Gtk.RadioButton.new_with_mnemonic(None, '_Mono')
-        self.stereo = Gtk.RadioButton.new_with_mnemonic_from_widget(self.mono, '_Stereo')
+        grid.attach(Gtk.Label(label="Mode", halign=Gtk.Align.START), 0, 1, 1, 1)
+        self.mono = Gtk.RadioButton.new_with_mnemonic(None, "_Mono")
+        self.stereo = Gtk.RadioButton.new_with_mnemonic_from_widget(self.mono, "_Stereo")
         grid.attach(self.mono, 1, 1, 1, 1)
         grid.attach(self.stereo, 2, 1, 1, 1)
 
         grid = Gtk.Grid()
-        vbox.pack_start(self.create_frame('MIDI Control Changes', grid), True, True, 0)
+        vbox.pack_start(self.create_frame("MIDI Control Changes", grid), True, True, 0)
         grid.set_row_spacing(8)
         grid.set_column_spacing(8)
         grid.set_column_homogeneous(True)
 
         cc_tooltip = "{} MIDI Control Change number (0-127, set to -1 to assign next free CC #)"
-        volume_label = Gtk.Label.new_with_mnemonic('_Volume')
+        volume_label = Gtk.Label.new_with_mnemonic("_Volume")
         volume_label.set_halign(Gtk.Align.START)
         grid.attach(volume_label, 0, 0, 1, 1)
         self.entry_volume_cc = Gtk.SpinButton.new_with_range(-1, 127, 1)
         self.entry_volume_cc.set_tooltip_text(cc_tooltip.format("Volume"))
         volume_label.set_mnemonic_widget(self.entry_volume_cc)
         grid.attach(self.entry_volume_cc, 1, 0, 1, 1)
-        self.button_sense_midi_volume = Gtk.Button('Learn')
-        self.button_sense_midi_volume.connect('clicked',
-                        self.on_sense_midi_volume_clicked)
+        self.button_sense_midi_volume = Gtk.Button("Learn")
+        self.button_sense_midi_volume.connect("clicked", self.on_sense_midi_volume_clicked)
         grid.attach(self.button_sense_midi_volume, 2, 0, 1, 1)
 
-        balance_label = Gtk.Label.new_with_mnemonic('_Balance')
+        balance_label = Gtk.Label.new_with_mnemonic("_Balance")
         balance_label.set_halign(Gtk.Align.START)
         grid.attach(balance_label, 0, 1, 1, 1)
         self.entry_balance_cc = Gtk.SpinButton.new_with_range(-1, 127, 1)
         self.entry_balance_cc.set_tooltip_text(cc_tooltip.format("Balance"))
         balance_label.set_mnemonic_widget(self.entry_balance_cc)
         grid.attach(self.entry_balance_cc, 1, 1, 1, 1)
-        self.button_sense_midi_balance = Gtk.Button('Learn')
-        self.button_sense_midi_balance.connect('clicked',
-                        self.on_sense_midi_balance_clicked)
+        self.button_sense_midi_balance = Gtk.Button("Learn")
+        self.button_sense_midi_balance.connect("clicked", self.on_sense_midi_balance_clicked)
         grid.attach(self.button_sense_midi_balance, 2, 1, 1, 1)
 
-        mute_label = Gtk.Label.new_with_mnemonic('M_ute')
+        mute_label = Gtk.Label.new_with_mnemonic("M_ute")
         mute_label.set_halign(Gtk.Align.START)
         grid.attach(mute_label, 0, 2, 1, 1)
         self.entry_mute_cc = Gtk.SpinButton.new_with_range(-1, 127, 1)
         self.entry_mute_cc.set_tooltip_text(cc_tooltip.format("Mute"))
         mute_label.set_mnemonic_widget(self.entry_mute_cc)
         grid.attach(self.entry_mute_cc, 1, 2, 1, 1)
-        self.button_sense_midi_mute = Gtk.Button('Learn')
-        self.button_sense_midi_mute.connect('clicked',
-                        self.on_sense_midi_mute_clicked)
+        self.button_sense_midi_mute = Gtk.Button("Learn")
+        self.button_sense_midi_mute.connect("clicked", self.on_sense_midi_mute_clicked)
         grid.attach(self.button_sense_midi_mute, 2, 2, 1, 1)
 
-        if (isinstance(self, NewChannelDialog) or (self.channel and
-            isinstance(self.channel, InputChannel))):
-            solo_label = Gtk.Label.new_with_mnemonic('S_olo')
+        if isinstance(self, NewChannelDialog) or (
+            self.channel and isinstance(self.channel, InputChannel)
+        ):
+            solo_label = Gtk.Label.new_with_mnemonic("S_olo")
             solo_label.set_halign(Gtk.Align.START)
             grid.attach(solo_label, 0, 3, 1, 1)
             self.entry_solo_cc = Gtk.SpinButton.new_with_range(-1, 127, 1)
             self.entry_solo_cc.set_tooltip_text(cc_tooltip.format("Solo"))
             solo_label.set_mnemonic_widget(self.entry_solo_cc)
             grid.attach(self.entry_solo_cc, 1, 3, 1, 1)
-            self.button_sense_midi_solo = Gtk.Button('Learn')
-            self.button_sense_midi_solo.connect('clicked',
-                            self.on_sense_midi_solo_clicked)
+            self.button_sense_midi_solo = Gtk.Button("Learn")
+            self.button_sense_midi_solo.connect("clicked", self.on_sense_midi_solo_clicked)
             grid.attach(self.button_sense_midi_solo, 2, 3, 1, 1)
 
         self.vbox.show_all()
@@ -966,7 +968,7 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         self.entry_volume_cc.set_value(self.channel.channel.volume_midi_cc)
         self.entry_balance_cc.set_value(self.channel.channel.balance_midi_cc)
         self.entry_mute_cc.set_value(self.channel.channel.mute_midi_cc)
-        if (self.channel and isinstance(self.channel, InputChannel)):
+        if self.channel and isinstance(self.channel, InputChannel):
             self.entry_solo_cc.set_value(self.channel.channel.solo_midi_cc)
 
     def sense_popup_dialog(self, entry):
@@ -981,14 +983,14 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         vbox = Gtk.Box(10, orientation=Gtk.Orientation.VERTICAL)
         window.add(vbox)
         window.timeout = 5
-        label = Gtk.Label(label='Please move the MIDI control you want to use for this function.')
+        label = Gtk.Label(label="Please move the MIDI control you want to use for this function.")
         vbox.pack_start(label, True, True, 0)
-        timeout_label = Gtk.Label(label='This window will close in 5 seconds')
+        timeout_label = Gtk.Label(label="This window will close in 5 seconds")
         vbox.pack_start(timeout_label, True, True, 0)
 
         def close_sense_timeout(window, entry):
             window.timeout -= 1
-            timeout_label.set_text('This window will close in %d seconds.' % window.timeout)
+            timeout_label.set_text("This window will close in %d seconds." % window.timeout)
             if window.timeout == 0:
                 window.destroy()
                 entry.set_value(self.mixer.last_midi_channel)
@@ -1019,12 +1021,12 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         if response_id == Gtk.ResponseType.APPLY:
             if name != self.channel.channel_name:
                 self.channel.channel_name = name
-            for control in ('volume', 'balance', 'mute', 'solo'):
-                widget = getattr(self, 'entry_{}_cc'.format(control), None)
+            for control in ("volume", "balance", "mute", "solo"):
+                widget = getattr(self, "entry_{}_cc".format(control), None)
                 if widget is not None:
                     value = int(widget.get_value())
                     if value != -1:
-                        setattr(self.channel.channel, '{}_midi_cc'.format(control), value)
+                        setattr(self.channel.channel, "{}_midi_cc".format(control), value)
 
         self.hide()
         return True
@@ -1034,8 +1036,9 @@ class ChannelPropertiesDialog(Gtk.Dialog):
         if len(entry.get_text()):
             if self.channel and self.channel.channel.name == entry.get_text():
                 sensitive = True
-            elif entry.get_text() not in [x.channel.name for x in self.app.channels] + \
-                        [x.channel.name for x in self.app.output_channels] + ['MAIN']:
+            elif entry.get_text() not in [x.channel.name for x in self.app.channels] + [
+                x.channel.name for x in self.app.output_channels
+            ] + ["MAIN"]:
                 sensitive = True
         self.ok_button.set_sensitive(sensitive)
 
@@ -1054,38 +1057,38 @@ class NewChannelDialog(ChannelPropertiesDialog):
 
     def add_initial_value_radio(self):
         grid = self.properties_grid
-        grid.attach(Gtk.Label(label='Value', halign=Gtk.Align.START), 0, 2, 1, 1)
-        self.minus_inf = Gtk.RadioButton.new_with_mnemonic(None, '-_Inf')
-        self.zero_dB = Gtk.RadioButton.new_with_mnemonic_from_widget(self.minus_inf, '_0dB')
+        grid.attach(Gtk.Label(label="Value", halign=Gtk.Align.START), 0, 2, 1, 1)
+        self.minus_inf = Gtk.RadioButton.new_with_mnemonic(None, "-_Inf")
+        self.zero_dB = Gtk.RadioButton.new_with_mnemonic_from_widget(self.minus_inf, "_0dB")
         grid.attach(self.minus_inf, 1, 2, 1, 1)
         grid.attach(self.zero_dB, 2, 2, 1, 1)
 
 
 class NewInputChannelDialog(NewChannelDialog):
-    def __init__(self, app, title='New Input Channel'):
+    def __init__(self, app, title="New Input Channel"):
         super().__init__(app, title=title)
 
     def fill_ui(self, **values):
-        self.entry_name.set_text(values.get('name', ''))
+        self.entry_name.set_text(values.get("name", ""))
         # don't set MIDI CCs to previously used values, because they
         # would overwrite existing mappings, if accepted.
         self.entry_volume_cc.set_value(-1)
         self.entry_balance_cc.set_value(-1)
         self.entry_mute_cc.set_value(-1)
         self.entry_solo_cc.set_value(-1)
-        self.stereo.set_active(values.get('stereo', True))
-        self.minus_inf.set_active(values.get('value', False))
+        self.stereo.set_active(values.get("stereo", True))
+        self.minus_inf.set_active(values.get("value", False))
         self.entry_name.grab_focus()
 
     def get_result(self):
         return {
-            'name': self.entry_name.get_text(),
-            'stereo': self.stereo.get_active(),
-            'volume_cc': int(self.entry_volume_cc.get_value()),
-            'balance_cc': int(self.entry_balance_cc.get_value()),
-            'mute_cc': int(self.entry_mute_cc.get_value()),
-            'solo_cc': int(self.entry_solo_cc.get_value()),
-            'value': self.minus_inf.get_active()
+            "name": self.entry_name.get_text(),
+            "stereo": self.stereo.get_active(),
+            "volume_cc": int(self.entry_volume_cc.get_value()),
+            "balance_cc": int(self.entry_balance_cc.get_value()),
+            "mute_cc": int(self.entry_mute_cc.get_value()),
+            "solo_cc": int(self.entry_solo_cc.get_value()),
+            "value": self.minus_inf.get_active(),
         }
 
 
@@ -1094,7 +1097,7 @@ class OutputChannelPropertiesDialog(ChannelPropertiesDialog):
         super().create_ui()
 
         grid = self.properties_grid
-        color_label = Gtk.Label.new_with_mnemonic('_Color')
+        color_label = Gtk.Label.new_with_mnemonic("_Color")
         color_label.set_halign(Gtk.Align.START)
         grid.attach(color_label, 0, 3, 1, 1)
         self.color_chooser_button = Gtk.ColorButton()
@@ -1103,9 +1106,9 @@ class OutputChannelPropertiesDialog(ChannelPropertiesDialog):
         grid.attach(self.color_chooser_button, 1, 3, 2, 1)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.vbox.pack_start(self.create_frame('Input Channels', vbox), True, True, 0)
+        self.vbox.pack_start(self.create_frame("Input Channels", vbox), True, True, 0)
 
-        self.display_solo_buttons = Gtk.CheckButton.new_with_mnemonic('_Display solo buttons')
+        self.display_solo_buttons = Gtk.CheckButton.new_with_mnemonic("_Display solo buttons")
         vbox.pack_start(self.display_solo_buttons, True, True, 0)
 
         self.vbox.show_all()
@@ -1126,11 +1129,11 @@ class OutputChannelPropertiesDialog(ChannelPropertiesDialog):
 
 
 class NewOutputChannelDialog(NewChannelDialog, OutputChannelPropertiesDialog):
-    def __init__(self, app, title='New Output Channel'):
+    def __init__(self, app, title="New Output Channel"):
         super().__init__(app, title=title)
 
     def fill_ui(self, **values):
-        self.entry_name.set_text(values.get('name', ''))
+        self.entry_name.set_text(values.get("name", ""))
 
         # TODO: disable mode for output channels as mono output channels may
         # not be correctly handled yet.
@@ -1142,23 +1145,23 @@ class NewOutputChannelDialog(NewChannelDialog, OutputChannelPropertiesDialog):
         self.entry_volume_cc.set_value(-1)
         self.entry_balance_cc.set_value(-1)
         self.entry_mute_cc.set_value(-1)
-        self.stereo.set_active(values.get('stereo', True))
-        self.minus_inf.set_active(values.get('value', False))
+        self.stereo.set_active(values.get("stereo", True))
+        self.minus_inf.set_active(values.get("value", False))
         # choose a new random color for each new output channel
         self.color_chooser_button.set_rgba(random_color())
-        self.display_solo_buttons.set_active(values.get('display_solo_buttons', False))
+        self.display_solo_buttons.set_active(values.get("display_solo_buttons", False))
         self.entry_name.grab_focus()
 
     def get_result(self):
         return {
-            'name': self.entry_name.get_text(),
-            'stereo': self.stereo.get_active(),
-            'volume_cc': int(self.entry_volume_cc.get_value()),
-            'balance_cc': int(self.entry_balance_cc.get_value()),
-            'mute_cc': int(self.entry_mute_cc.get_value()),
-            'display_solo_buttons': self.display_solo_buttons.get_active(),
-            'color': self.color_chooser_button.get_rgba(),
-            'value': self.minus_inf.get_active()
+            "name": self.entry_name.get_text(),
+            "stereo": self.stereo.get_active(),
+            "volume_cc": int(self.entry_volume_cc.get_value()),
+            "balance_cc": int(self.entry_balance_cc.get_value()),
+            "mute_cc": int(self.entry_mute_cc.get_value()),
+            "display_solo_buttons": self.display_solo_buttons.get_active(),
+            "color": self.color_chooser_button.get_rgba(),
+            "value": self.minus_inf.get_active(),
         }
 
 
@@ -1179,7 +1182,7 @@ class ControlGroup(Gtk.Alignment):
 
         self.vbox.pack_start(self.hbox, True, True, BUTTON_PADDING)
         hbox_context = self.hbox.get_style_context()
-        hbox_context.add_class('control_group')
+        hbox_context.add_class("control_group")
 
         name = output_channel.channel.name
         self.label = Gtk.Label(name)
@@ -1235,8 +1238,9 @@ class ControlGroup(Gtk.Alignment):
         self.app.update_monitor(self)
 
     def on_prefader_toggled(self, button):
-        self.output_channel.channel.set_in_prefader(self.input_channel.channel,
-                                                    button.get_active())
+        self.output_channel.channel.set_in_prefader(
+            self.input_channel.channel, button.get_active()
+        )
 
     def narrow(self):
         self.hbox.remove(self.label)
@@ -1244,15 +1248,23 @@ class ControlGroup(Gtk.Alignment):
 
     def widen(self):
         self.hbox.pack_start(self.label, False, False, BUTTON_PADDING)
-        self.hbox.set_child_packing(self.buttons_box, False, False, BUTTON_PADDING,
-                                    Gtk.PackType.END)
+        self.hbox.set_child_packing(
+            self.buttons_box, False, False, BUTTON_PADDING, Gtk.PackType.END
+        )
 
 
+GObject.signal_new(
+    "input-channel-order-changed",
+    InputChannel,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [GObject.TYPE_STRING, GObject.TYPE_STRING],
+)
 
-GObject.signal_new("input-channel-order-changed", InputChannel,
-                GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                None, [GObject.TYPE_STRING, GObject.TYPE_STRING])
-
-GObject.signal_new("output-channel-order-changed", OutputChannel,
-                GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                None, [GObject.TYPE_STRING, GObject.TYPE_STRING])
+GObject.signal_new(
+    "output-channel-order-changed",
+    OutputChannel,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [GObject.TYPE_STRING, GObject.TYPE_STRING],
+)

--- a/gui.py
+++ b/gui.py
@@ -41,9 +41,8 @@ def lookup_scale(scales, scale_id):
 
 
 class Factory(GObject.GObject, SerializedObject):
-
     def __init__(self, topwindow, meter_scales, slider_scales):
-        self.midi_behavior_modes = [ 'Jump To Value', 'Pick Up' ]
+        self.midi_behavior_modes = ["Jump To Value", "Pick Up"]
         GObject.GObject.__init__(self)
         self.topwindow = topwindow
         self.meter_scales = meter_scales
@@ -51,14 +50,18 @@ class Factory(GObject.GObject, SerializedObject):
         self.set_default_preferences()
         if xdg:
             self.config = configparser.ConfigParser()
-            self.path = os.path.join(BaseDirectory.save_config_path('jack_mixer'), 'preferences.ini')
+            self.path = os.path.join(
+                BaseDirectory.save_config_path("jack_mixer"), "preferences.ini"
+            )
             if os.path.isfile(self.path):
                 self.read_preferences()
             else:
                 self.write_preferences()
         else:
-            log.warning("Cannot load PyXDG. Your preferences will not be preserved across "
-                        "jack_mixer invocations")
+            log.warning(
+                "Cannot load PyXDG. Your preferences will not be preserved across "
+                "jack_mixer invocations"
+            )
 
     def set_default_preferences(self):
         self.confirm_quit = False
@@ -66,49 +69,53 @@ class Factory(GObject.GObject, SerializedObject):
         self.default_slider_scale = self.slider_scales[0]
         self.midi_behavior_mode = 0
         self.use_custom_widgets = False
-        self.vumeter_color = '#ccb300'
-        self.vumeter_color_scheme = 'default'
+        self.vumeter_color = "#ccb300"
+        self.vumeter_color_scheme = "default"
 
     def read_preferences(self):
         self.config.read(self.path)
-        self.confirm_quit = self.config.getboolean('Preferences', 'confirm_quit',
-                                                   fallback=self.confirm_quit)
+        self.confirm_quit = self.config.getboolean(
+            "Preferences", "confirm_quit", fallback=self.confirm_quit
+        )
 
-        scale_id = self.config['Preferences']['default_meter_scale']
+        scale_id = self.config["Preferences"]["default_meter_scale"]
         self.default_meter_scale = lookup_scale(self.meter_scales, scale_id)
         if not self.default_meter_scale:
             self.default_meter_scale = self.meter_scales[0]
 
-        scale_id = self.config['Preferences']['default_slider_scale']
+        scale_id = self.config["Preferences"]["default_slider_scale"]
         self.default_slider_scale = lookup_scale(self.slider_scales, scale_id)
         if not self.default_slider_scale:
             self.default_slider_scale = slider_scales[0]
 
         try:
-            self.midi_behavior_mode = self.config.getint('Preferences', 'midi_behavior_mode',
-                                                         fallback=self.midi_behavior_mode)
+            self.midi_behavior_mode = self.config.getint(
+                "Preferences", "midi_behavior_mode", fallback=self.midi_behavior_mode
+            )
         except (TypeError, ValueError):
             # use default value
             pass
 
-        self.use_custom_widgets = self.config.getboolean('Preferences', 'use_custom_widgets',
-                                                         fallback=self.use_custom_widgets)
-        self.vumeter_color = self.config.get('Preferences', 'vumeter_color',
-                                             fallback=self.vumeter_color)
-        self.vumeter_color_scheme = self.config.get('Preferences', 'vumeter_color_scheme',
-                                                    fallback=self.vumeter_color_scheme)
-
+        self.use_custom_widgets = self.config.getboolean(
+            "Preferences", "use_custom_widgets", fallback=self.use_custom_widgets
+        )
+        self.vumeter_color = self.config.get(
+            "Preferences", "vumeter_color", fallback=self.vumeter_color
+        )
+        self.vumeter_color_scheme = self.config.get(
+            "Preferences", "vumeter_color_scheme", fallback=self.vumeter_color_scheme
+        )
 
     def write_preferences(self):
-        self.config['Preferences'] = {}
-        self.config['Preferences']['confirm_quit'] = str(self.confirm_quit)
-        self.config['Preferences']['default_meter_scale'] = self.default_meter_scale.scale_id
-        self.config['Preferences']['default_slider_scale'] = self.default_slider_scale.scale_id
-        self.config['Preferences']['midi_behavior_mode'] = str(self.midi_behavior_mode)
-        self.config['Preferences']['use_custom_widgets'] = str(self.use_custom_widgets)
-        self.config['Preferences']['vumeter_color'] = self.vumeter_color
-        self.config['Preferences']['vumeter_color_scheme'] = self.vumeter_color_scheme
-        with open(self.path, 'w') as configfile:
+        self.config["Preferences"] = {}
+        self.config["Preferences"]["confirm_quit"] = str(self.confirm_quit)
+        self.config["Preferences"]["default_meter_scale"] = self.default_meter_scale.scale_id
+        self.config["Preferences"]["default_slider_scale"] = self.default_slider_scale.scale_id
+        self.config["Preferences"]["midi_behavior_mode"] = str(self.midi_behavior_mode)
+        self.config["Preferences"]["use_custom_widgets"] = str(self.use_custom_widgets)
+        self.config["Preferences"]["vumeter_color"] = self.vumeter_color
+        self.config["Preferences"]["vumeter_color_scheme"] = self.vumeter_color_scheme
+        with open(self.path, "w") as configfile:
             self.config.write(configfile)
             configfile.close()
 
@@ -116,27 +123,29 @@ class Factory(GObject.GObject, SerializedObject):
         self.confirm_quit = confirm_quit
         if xdg:
             self.write_preferences()
-        self.emit('confirm-quit-changed', self.confirm_quit)
+        self.emit("confirm-quit-changed", self.confirm_quit)
 
     def set_default_meter_scale(self, scale):
         if scale:
             self.default_meter_scale = scale
             if xdg:
                 self.write_preferences()
-            self.emit('default-meter-scale-changed', self.default_meter_scale)
+            self.emit("default-meter-scale-changed", self.default_meter_scale)
         else:
-            log.warning('Ignoring default_meter_scale setting, because "%s" scale is not known.',
-                        scale)
+            log.warning(
+                'Ignoring default_meter_scale setting, because "%s" scale is not known.', scale
+            )
 
     def set_default_slider_scale(self, scale):
         if scale:
             self.default_slider_scale = scale
             if xdg:
                 self.write_preferences()
-            self.emit('default-slider-scale-changed', self.default_slider_scale)
+            self.emit("default-slider-scale-changed", self.default_slider_scale)
         else:
-            log.warning('Ignoring default_slider_scale setting, because "%s" scale is not known.',
-                        scale)
+            log.warning(
+                'Ignoring default_slider_scale setting, because "%s" scale is not known.', scale
+            )
 
     def set_midi_behavior_mode(self, mode):
         self.midi_behavior_mode = int(mode)
@@ -146,19 +155,19 @@ class Factory(GObject.GObject, SerializedObject):
         self.use_custom_widgets = use_custom
         if xdg:
             self.write_preferences()
-        self.emit('use-custom-widgets-changed', self.use_custom_widgets)
+        self.emit("use-custom-widgets-changed", self.use_custom_widgets)
 
     def set_vumeter_color(self, color):
         self.vumeter_color = color
         if xdg:
             self.write_preferences()
-        self.emit('vumeter-color-changed', self.vumeter_color)
+        self.emit("vumeter-color-changed", self.vumeter_color)
 
     def set_vumeter_color_scheme(self, color_scheme):
         self.vumeter_color_scheme = color_scheme
         if xdg:
             self.write_preferences()
-        self.emit('vumeter-color-scheme-changed', self.vumeter_color_scheme)
+        self.emit("vumeter-color-scheme-changed", self.vumeter_color_scheme)
 
     def get_confirm_quit(self):
         return self.confirm_quit
@@ -182,66 +191,94 @@ class Factory(GObject.GObject, SerializedObject):
         return self.vumeter_color_scheme
 
     def emit_midi_behavior_mode(self):
-        self.emit('midi-behavior-mode-changed', self.midi_behavior_mode)
+        self.emit("midi-behavior-mode-changed", self.midi_behavior_mode)
 
     @classmethod
     def serialization_name(cls):
-        return 'gui_factory'
+        return "gui_factory"
 
     def serialize(self, object_backend):
-        object_backend.add_property('confirm-quit', str(self.get_confirm_quit()))
-        object_backend.add_property('default_meter_scale',
-                                    self.get_default_meter_scale().scale_id)
-        object_backend.add_property('default_slider_scale',
-                                    self.get_default_slider_scale().scale_id)
-        object_backend.add_property('midi_behavior_mode', str(self.get_midi_behavior_mode()))
-        object_backend.add_property('use_custom_widgets', str(self.get_use_custom_widgets()))
-        object_backend.add_property('vumeter_color', self.get_vumeter_color())
-        object_backend.add_property('vumeter_color_scheme', self.get_vumeter_color_scheme())
+        object_backend.add_property("confirm-quit", str(self.get_confirm_quit()))
+        object_backend.add_property("default_meter_scale", self.get_default_meter_scale().scale_id)
+        object_backend.add_property(
+            "default_slider_scale", self.get_default_slider_scale().scale_id
+        )
+        object_backend.add_property("midi_behavior_mode", str(self.get_midi_behavior_mode()))
+        object_backend.add_property("use_custom_widgets", str(self.get_use_custom_widgets()))
+        object_backend.add_property("vumeter_color", self.get_vumeter_color())
+        object_backend.add_property("vumeter_color_scheme", self.get_vumeter_color_scheme())
 
     def unserialize_property(self, name, value):
-        if name == 'confirm_quit':
-            self.set_confirm_quit(value == 'True')
+        if name == "confirm_quit":
+            self.set_confirm_quit(value == "True")
             return True
-        elif name == 'default_meter_scale':
+        elif name == "default_meter_scale":
             self.set_default_meter_scale(lookup_scale(self.meter_scales, value))
             return True
-        elif name == 'default_slider_scale':
+        elif name == "default_slider_scale":
             self.set_default_slider_scale(lookup_scale(self.slider_scales, value))
             return True
-        elif name == 'midi_behavior_mode':
+        elif name == "midi_behavior_mode":
             self.set_midi_behavior_mode(int(value))
             return True
-        elif name == 'use_custom_widgets':
-            self.set_use_custom_widgets(value == 'True')
+        elif name == "use_custom_widgets":
+            self.set_use_custom_widgets(value == "True")
             return True
-        elif name == 'vumeter_color':
+        elif name == "vumeter_color":
             self.set_vumeter_color(value)
             return True
-        elif name == 'vumeter_color_scheme':
+        elif name == "vumeter_color_scheme":
             self.set_vumeter_color_scheme(value)
             return True
         return False
 
 
-GObject.signal_new('confirm-quit-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [bool])
-GObject.signal_new('default-meter-scale-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [GObject.TYPE_PYOBJECT])
-GObject.signal_new('default-slider-scale-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [GObject.TYPE_PYOBJECT])
-GObject.signal_new('midi-behavior-mode-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [int])
-GObject.signal_new('use-custom-widgets-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [bool])
-GObject.signal_new('vumeter-color-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [str])
-GObject.signal_new('vumeter-color-scheme-changed', Factory,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
-                   None, [str])
+GObject.signal_new(
+    "confirm-quit-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [bool],
+)
+GObject.signal_new(
+    "default-meter-scale-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [GObject.TYPE_PYOBJECT],
+)
+GObject.signal_new(
+    "default-slider-scale-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [GObject.TYPE_PYOBJECT],
+)
+GObject.signal_new(
+    "midi-behavior-mode-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [int],
+)
+GObject.signal_new(
+    "use-custom-widgets-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [bool],
+)
+GObject.signal_new(
+    "vumeter-color-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [str],
+)
+GObject.signal_new(
+    "vumeter-color-scheme-changed",
+    Factory,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [str],
+)

--- a/meter.py
+++ b/meter.py
@@ -30,7 +30,7 @@ class MeterWidget(Gtk.DrawingArea):
         log.debug("Creating MeterWidget for scale %s", scale)
         super().__init__()
         self.scale = scale
-        self.color_bg = Gdk.Color(0,0,0)
+        self.color_bg = Gdk.Color(0, 0, 0)
         self.color_value = None
         self.color_mark = Gdk.Color(int(65535 * 0.2), int(65535 * 0.2), int(65535 * 0.2))
         self.width = 0
@@ -49,8 +49,9 @@ class MeterWidget(Gtk.DrawingArea):
         return self.widen(False)
 
     def widen(self, flag=True):
-        self.set_size_request(self.preferred_width if flag else self.min_width,
-                              self.preferred_height)
+        self.set_size_request(
+            self.preferred_width if flag else self.min_width, self.preferred_height
+        )
 
     def set_color(self, color):
         self.color_value = color
@@ -79,10 +80,8 @@ class MeterWidget(Gtk.DrawingArea):
     def draw_background(self, cairo_ctx):
         if not self.cache_surface:
             self.cache_surface = cairo.Surface.create_similar(
-                            cairo_ctx.get_target(),
-                            cairo.CONTENT_COLOR,
-                            int(self.width),
-                            int(self.height))
+                cairo_ctx.get_target(), cairo.CONTENT_COLOR, int(self.width), int(self.height)
+            )
             cache_cairo_ctx = cairo.Context(self.cache_surface)
 
             cache_cairo_ctx.set_source_rgba(0, 0, 0, 0)
@@ -92,7 +91,7 @@ class MeterWidget(Gtk.DrawingArea):
             cache_cairo_ctx.set_source_rgba(0.2, 0.2, 0.2, 1)
             cache_cairo_ctx.select_font_face("Fixed")
             cache_cairo_ctx.set_font_size(self.font_size)
-            glyph_width = self.font_size * 3 / 5 # avarage glyph ratio
+            glyph_width = self.font_size * 3 / 5  # avarage glyph ratio
 
             for mark in self.scale.get_marks():
                 mark_position = int(self.height * (1 - mark.scale))
@@ -108,11 +107,14 @@ class MeterWidget(Gtk.DrawingArea):
 
     def draw_value(self, cairo_ctx, value, x, width):
         if self.color_value is not None:
-            cairo_ctx.set_source_rgb(self.color_value.red/65535.,
-                    self.color_value.green/65535., self.color_value.blue/65535.)
+            cairo_ctx.set_source_rgb(
+                self.color_value.red / 65535.0,
+                self.color_value.green / 65535.0,
+                self.color_value.blue / 65535.0,
+            )
         else:
             height = self.height
-            gradient = cairo.LinearGradient(1, 1, width-1, height-1)
+            gradient = cairo.LinearGradient(1, 1, width - 1, height - 1)
 
             if self.scale.scale_id == "K20":
                 gradient.add_color_stop_rgb(0, 1, 0, 0)
@@ -121,8 +123,8 @@ class MeterWidget(Gtk.DrawingArea):
                 gradient.add_color_stop_rgb(1, 0, 0, 1)
             elif self.scale.scale_id == "K14":
                 gradient.add_color_stop_rgb(0, 1, 0, 0)
-                gradient.add_color_stop_rgb(1-self.scale.db_to_scale(-14), 1, 1, 0)
-                gradient.add_color_stop_rgb(1-self.scale.db_to_scale(-24), 0, 1, 0)
+                gradient.add_color_stop_rgb(1 - self.scale.db_to_scale(-14), 1, 1, 0)
+                gradient.add_color_stop_rgb(1 - self.scale.db_to_scale(-24), 0, 1, 0)
                 gradient.add_color_stop_rgb(1, 0, 0, 1)
             else:
                 gradient.add_color_stop_rgb(0, 1, 0, 0)
@@ -155,8 +157,8 @@ class MonoMeterWidget(MeterWidget):
 
     def draw(self, widget, cairo_ctx):
         self.draw_background(cairo_ctx)
-        self.draw_value(cairo_ctx, self.value, self.width/4.0, self.width/2.0)
-        self.draw_peak(cairo_ctx, self.pk, self.width/4.0, self.width/2.0)
+        self.draw_value(cairo_ctx, self.value, self.width / 4.0, self.width / 2.0)
+        self.draw_peak(cairo_ctx, self.pk, self.width / 4.0, self.width / 2.0)
 
     def set_values(self, pk, value):
         if value == self.raw_value and pk == self.raw_pk:
@@ -169,7 +171,9 @@ class MonoMeterWidget(MeterWidget):
         self.value = self.scale.db_to_scale(value)
         self.pk = self.scale.db_to_scale(pk)
 
-        if (abs(old_value-self.value) * self.height) > 0.01 or (abs(old_pk-self.pk) * self.height) > 0.01:
+        if (abs(old_value - self.value) * self.height) > 0.01 or (
+            abs(old_pk - self.pk) * self.height
+        ) > 0.01:
             self.invalidate_all()
 
 
@@ -190,13 +194,18 @@ class StereoMeterWidget(MeterWidget):
 
     def draw(self, widget, cairo_ctx):
         self.draw_background(cairo_ctx)
-        self.draw_value(cairo_ctx, self.left, self.width/5.0, self.width/5.0)
-        self.draw_value(cairo_ctx, self.right, self.width/5.0 * 3.0, self.width/5.0)
-        self.draw_peak(cairo_ctx, self.pk_left, self.width/5.0, self.width/5.0)
-        self.draw_peak(cairo_ctx, self.pk_right, self.width/5.0 * 3.0, self.width/5.0)
+        self.draw_value(cairo_ctx, self.left, self.width / 5.0, self.width / 5.0)
+        self.draw_value(cairo_ctx, self.right, self.width / 5.0 * 3.0, self.width / 5.0)
+        self.draw_peak(cairo_ctx, self.pk_left, self.width / 5.0, self.width / 5.0)
+        self.draw_peak(cairo_ctx, self.pk_right, self.width / 5.0 * 3.0, self.width / 5.0)
 
     def set_values(self, pk_l, pk_r, left, right):
-        if left == self.raw_left and right == self.raw_right and pk_l == self.raw_left_pk and pk_r == self.raw_right_pk:
+        if (
+            left == self.raw_left
+            and right == self.raw_right
+            and pk_l == self.raw_left_pk
+            and pk_r == self.raw_right_pk
+        ):
             return
 
         self.raw_left = left
@@ -212,5 +221,10 @@ class StereoMeterWidget(MeterWidget):
         self.pk_left = self.scale.db_to_scale(pk_l)
         self.pk_right = self.scale.db_to_scale(pk_r)
 
-        if (abs(old_left-self.left) * self.height) > 0.01 or (abs(old_right-self.right) * self.height) > 0.01 or (abs(old_pk_left-self.pk_left) * self.height) > 0.01 or (abs(old_pk_right-self.pk_right) * self.height) > 0.01:
+        if (
+            (abs(old_left - self.left) * self.height) > 0.01
+            or (abs(old_right - self.right) * self.height) > 0.01
+            or (abs(old_pk_left - self.pk_left) * self.height) > 0.01
+            or (abs(old_pk_right - self.pk_right) * self.height) > 0.01
+        ):
             self.invalidate_all()

--- a/preferences.py
+++ b/preferences.py
@@ -20,21 +20,22 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject
 
+
 class PreferencesDialog(Gtk.Dialog):
     def __init__(self, parent):
         self.app = parent
         GObject.GObject.__init__(self)
-        self.set_title( '')
+        self.set_title("")
         self.create_ui()
-        self.connect('response', self.on_response_cb)
-        self.connect('delete-event', self.on_response_cb)
+        self.connect("response", self.on_response_cb)
+        self.connect("delete-event", self.on_response_cb)
 
     def create_frame(self, label, child):
         frame = Gtk.Frame()
-        frame.set_label('')
+        frame.set_label("")
         frame.set_border_width(3)
         frame.set_shadow_type(Gtk.ShadowType.NONE)
-        frame.get_label_widget().set_markup('<b>%s</b>' % label)
+        frame.get_label_widget().set_markup("<b>%s</b>" % label)
 
         alignment = Gtk.Alignment.new(0, 0, 12, 0)
         frame.add(alignment)
@@ -47,64 +48,62 @@ class PreferencesDialog(Gtk.Dialog):
         self.vbox.add(vbox)
 
         interface_vbox = Gtk.VBox()
-        self.confirm_quit_checkbutton = Gtk.CheckButton('Confirm quit')
-        self.confirm_quit_checkbutton.set_tooltip_text("Always ask for confirmation before "
-                                                       "quitting the application")
+        self.confirm_quit_checkbutton = Gtk.CheckButton("Confirm quit")
+        self.confirm_quit_checkbutton.set_tooltip_text(
+            "Always ask for confirmation before " "quitting the application"
+        )
         self.confirm_quit_checkbutton.set_active(self.app.gui_factory.get_confirm_quit())
-        self.confirm_quit_checkbutton.connect('toggled', self.on_confirm_quit_toggled)
+        self.confirm_quit_checkbutton.connect("toggled", self.on_confirm_quit_toggled)
         interface_vbox.pack_start(self.confirm_quit_checkbutton, True, True, 0)
 
-        self.custom_widgets_checkbutton = Gtk.CheckButton('Use custom widgets')
-        self.custom_widgets_checkbutton.set_active(
-                        self.app.gui_factory.get_use_custom_widgets())
-        self.custom_widgets_checkbutton.connect('toggled',
-                        self.on_custom_widget_toggled)
+        self.custom_widgets_checkbutton = Gtk.CheckButton("Use custom widgets")
+        self.custom_widgets_checkbutton.set_active(self.app.gui_factory.get_use_custom_widgets())
+        self.custom_widgets_checkbutton.connect("toggled", self.on_custom_widget_toggled)
         interface_vbox.pack_start(self.custom_widgets_checkbutton, True, True, 0)
 
-        self.vumeter_color_checkbutton = Gtk.CheckButton('Use custom vumeter color')
+        self.vumeter_color_checkbutton = Gtk.CheckButton("Use custom vumeter color")
         self.vumeter_color_checkbutton.set_active(
-                        self.app.gui_factory.get_vumeter_color_scheme() == 'solid')
-        self.vumeter_color_checkbutton.connect('toggled',
-                        self.on_vumeter_color_change)
+            self.app.gui_factory.get_vumeter_color_scheme() == "solid"
+        )
+        self.vumeter_color_checkbutton.connect("toggled", self.on_vumeter_color_change)
         interface_vbox.pack_start(self.vumeter_color_checkbutton, True, True, 0)
         hbox = Gtk.HBox()
         interface_vbox.pack_start(hbox, True, True, 0)
         self.custom_color_box = hbox
-        self.custom_color_box.set_sensitive(
-                        self.vumeter_color_checkbutton.get_active() == True)
-        hbox.pack_start(Gtk.Label('Custom color:'), True, True, 0)
+        self.custom_color_box.set_sensitive(self.vumeter_color_checkbutton.get_active() == True)
+        hbox.pack_start(Gtk.Label("Custom color:"), True, True, 0)
         self.vumeter_color_picker = Gtk.ColorButton()
-        self.vumeter_color_picker.set_color(Gdk.color_parse(
-                                self.app.gui_factory.get_vumeter_color()))
-        self.vumeter_color_picker.connect('color-set',
-                        self.on_vumeter_color_change)
+        self.vumeter_color_picker.set_color(
+            Gdk.color_parse(self.app.gui_factory.get_vumeter_color())
+        )
+        self.vumeter_color_picker.connect("color-set", self.on_vumeter_color_change)
         hbox.pack_start(self.vumeter_color_picker, True, True, 0)
 
-        vbox.pack_start(self.create_frame('Interface', interface_vbox), True, True, 0)
+        vbox.pack_start(self.create_frame("Interface", interface_vbox), True, True, 0)
 
         table = Gtk.Table(2, 2, False)
         table.set_row_spacings(5)
         table.set_col_spacings(5)
 
-        table.attach(Gtk.Label(label='Meter scale'), 0, 1, 0, 1)
+        table.attach(Gtk.Label(label="Meter scale"), 0, 1, 0, 1)
         self.meter_scale_combo = self.create_meter_store_and_combo()
         table.attach(self.meter_scale_combo, 1, 2, 0, 1)
 
-        table.attach(Gtk.Label(label='Slider scale'), 0, 1, 1, 2)
+        table.attach(Gtk.Label(label="Slider scale"), 0, 1, 1, 2)
         self.slider_scale_combo = self.create_slider_store_and_combo()
         table.attach(self.slider_scale_combo, 1, 2, 1, 2)
 
-        vbox.pack_start(self.create_frame('Scales', table), True, True, 0)
+        vbox.pack_start(self.create_frame("Scales", table), True, True, 0)
 
         table = Gtk.Table(1, 2, False)
         table.set_row_spacings(5)
         table.set_col_spacings(5)
 
-        table.attach(Gtk.Label(label='Control Behavior'), 0, 1, 0, 1)
+        table.attach(Gtk.Label(label="Control Behavior"), 0, 1, 0, 1)
         self.midi_behavior_combo = self.create_midi_behavior_combo()
         table.attach(self.midi_behavior_combo, 1, 2, 0, 1)
 
-        vbox.pack_start(self.create_frame('MIDI', table), True, True, 0)
+        vbox.pack_start(self.create_frame("MIDI", table), True, True, 0)
         self.vbox.show_all()
 
         self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)
@@ -121,10 +120,9 @@ class PreferencesDialog(Gtk.Dialog):
         meter_scale_combo = Gtk.ComboBox.new_with_model(store)
         cell = Gtk.CellRendererText()
         meter_scale_combo.pack_start(cell, True)
-        meter_scale_combo.add_attribute(cell, 'text', 0)
+        meter_scale_combo.add_attribute(cell, "text", 0)
         meter_scale_combo.set_active_iter(active_iter)
-        meter_scale_combo.connect('changed',
-                        self.on_meter_scale_combo_changed)
+        meter_scale_combo.connect("changed", self.on_meter_scale_combo_changed)
 
         return meter_scale_combo
 
@@ -140,10 +138,9 @@ class PreferencesDialog(Gtk.Dialog):
         slider_scale_combo = Gtk.ComboBox.new_with_model(store)
         cell = Gtk.CellRendererText()
         slider_scale_combo.pack_start(cell, True)
-        slider_scale_combo.add_attribute(cell, 'text', 0)
+        slider_scale_combo.add_attribute(cell, "text", 0)
         slider_scale_combo.set_active_iter(active_iter)
-        slider_scale_combo.connect('changed',
-                        self.on_slider_scale_combo_changed)
+        slider_scale_combo.connect("changed", self.on_slider_scale_combo_changed)
 
         return slider_scale_combo
 
@@ -152,7 +149,7 @@ class PreferencesDialog(Gtk.Dialog):
         for i, mode in enumerate(self.app.gui_factory.midi_behavior_modes):
             combo.append(str(i), mode)
         combo.set_active(self.app.gui_factory.get_midi_behavior_mode())
-        combo.connect('changed', self.on_midi_behavior_combo_changed)
+        combo.connect("changed", self.on_midi_behavior_combo_changed)
         return combo
 
     def on_response_cb(self, dlg, response_id, *args):
@@ -174,20 +171,18 @@ class PreferencesDialog(Gtk.Dialog):
         self.app.gui_factory.set_midi_behavior_mode(active)
 
     def on_vumeter_color_change(self, *args):
-        color_scheme = 'default'
+        color_scheme = "default"
         if self.vumeter_color_checkbutton.get_active():
-            color_scheme = 'solid'
+            color_scheme = "solid"
         self.app.gui_factory.set_vumeter_color_scheme(color_scheme)
 
         color = self.vumeter_color_picker.get_color().to_string()
         self.app.gui_factory.set_vumeter_color(color)
 
-        self.custom_color_box.set_sensitive(
-                        self.vumeter_color_checkbutton.get_active() == True)
+        self.custom_color_box.set_sensitive(self.vumeter_color_checkbutton.get_active() == True)
 
     def on_confirm_quit_toggled(self, *args):
         self.app.gui_factory.set_confirm_quit(self.confirm_quit_checkbutton.get_active())
 
     def on_custom_widget_toggled(self, *args):
-        self.app.gui_factory.set_use_custom_widgets(
-                        self.custom_widgets_checkbutton.get_active())
+        self.app.gui_factory.set_use_custom_widgets(self.custom_widgets_checkbutton.get_active())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 99
+target-version = ['py36', 'py37', 'py38']
+force-exclude = 'nsmclient\.py'

--- a/scale.py
+++ b/scale.py
@@ -25,8 +25,9 @@ log = logging.getLogger(__name__)
 
 
 class Mark:
-    '''Encapsulates scale linear function edge and coefficients for scale = a * dB + b formula'''
-    def __init__(self, db, scale, text = None):
+    """Encapsulates scale linear function edge and coefficients for scale = a * dB + b formula"""
+
+    def __init__(self, db, scale, text=None):
         self.db = db
         self.scale = scale
         if text == None:
@@ -34,15 +35,17 @@ class Mark:
         else:
             self.text = text
 
+
 class Base:
-    '''Scale abstraction, various scale implementation derive from this class'''
+    """Scale abstraction, various scale implementation derive from this class"""
+
     def __init__(self, scale_id, description):
         self.marks = []
         self.scale_id = scale_id
         self.description = description
         self.scale = jack_mixer_c.Scale()
 
-    def add_threshold(self, db, scale, is_mark, text = None):
+    def add_threshold(self, db, scale, is_mark, text=None):
         self.scale.add_threshold(db, scale)
         if is_mark:
             self.marks.append(Mark(db, scale, text))
@@ -51,12 +54,12 @@ class Base:
         self.scale.calculate_coefficients()
 
     def db_to_scale(self, db):
-        '''Convert dBFS value to number in range 0.0-1.0 used in GUI'''
-        #log.debug("db_to_scale(%f)", db)
+        """Convert dBFS value to number in range 0.0-1.0 used in GUI"""
+        # log.debug("db_to_scale(%f)", db)
         return self.scale.db_to_scale(db)
 
     def scale_to_db(self, scale):
-        '''Convert number in range 0.0-1.0 used in GUI to dBFS value'''
+        """Convert number in range 0.0-1.0 used in GUI to dBFS value"""
         return self.scale.scale_to_db(scale)
 
     def add_mark(self, db):
@@ -75,10 +78,14 @@ class Base:
 # Adapted from meterbridge, may be wrong, I'm not buying standards, event if they cost $45
 # If someone has the standard, please either share it with me or fix the code.
 class IEC268(Base):
-    '''IEC 60268-18 Peak programme level meters - Digital audio peak level meter'''
+    """IEC 60268-18 Peak programme level meters - Digital audio peak level meter"""
+
     def __init__(self):
-        Base.__init__(self, "iec_268",
-                      "IEC 60268-18 Peak programme level meters - Digital audio peak level meter")
+        Base.__init__(
+            self,
+            "iec_268",
+            "IEC 60268-18 Peak programme level meters - Digital audio peak level meter",
+        )
         self.add_threshold(-70.0, 0.0, False)
         self.add_threshold(-60.0, 0.05, True)
         self.add_threshold(-50.0, 0.075, True)
@@ -96,11 +103,15 @@ class IEC268(Base):
 
 
 class IEC268Minimalistic(Base):
-    '''IEC 60268-18 Peak programme level meters - Digital audio peak level meter,
-       fewer marks'''
+    """IEC 60268-18 Peak programme level meters - Digital audio peak level meter,
+    fewer marks"""
+
     def __init__(self):
-        Base.__init__(self, 'iec_268_minimalistic',
-                      'IEC 60268-18 Peak programme level meters - Digital audio peak level meter, fewer marks')
+        Base.__init__(
+            self,
+            "iec_268_minimalistic",
+            "IEC 60268-18 Peak programme level meters - Digital audio peak level meter, fewer marks",
+        )
         self.add_threshold(-70.0, 0.0, False)
         self.add_threshold(-60.0, 0.05, True)
         self.add_threshold(-50.0, 0.075, False)
@@ -114,7 +125,8 @@ class IEC268Minimalistic(Base):
 
 
 class Linear70dB(Base):
-    '''Linear scale with range from -70 to 0 dBFS'''
+    """Linear scale with range from -70 to 0 dBFS"""
+
     def __init__(self):
         Base.__init__(self, "linear_70dB", "Linear scale with range from -70 to 0 dBFS")
         self.add_threshold(-70.0, 0.0, False)
@@ -134,7 +146,8 @@ class Linear70dB(Base):
 
 
 class Linear30dB(Base):
-    '''Linear scale with range from -30 to +30 dBFS'''
+    """Linear scale with range from -30 to +30 dBFS"""
+
     def __init__(self):
         Base.__init__(self, "linear_30dB", "Linear scale with range from -30 to +30 dBFS")
         self.add_threshold(-30.0, 0.0, False)
@@ -142,8 +155,10 @@ class Linear30dB(Base):
         self.calculate_coefficients()
         self.scale_marks()
 
+
 class K20(Base):
-    '''K20 scale'''
+    """K20 scale"""
+
     def __init__(self):
         Base.__init__(self, "K20", "K20 scale")
         self.add_mark(-200, "")
@@ -164,63 +179,71 @@ class K20(Base):
         self.add_mark(0, "20")
 
     def db_to_scale(self, db):
-        v = math.pow(10.0, db/20.0)
-        return self.mapk20(v)/450.0
+        v = math.pow(10.0, db / 20.0)
+        return self.mapk20(v) / 450.0
 
     def add_mark(self, db, text):
         self.marks.append(Mark(db, self.db_to_scale(db), text))
 
     def mapk20(self, v):
-        if v < 0.001: return (24000 * v)
+        if v < 0.001:
+            return 24000 * v
         v = math.log10(v) + 3
-        if v < 2.0: return (24.3 + v * (100 + v * 16))
-        if v > 3.0: v = 3.0
-        return (v * 161.7 - 35.1)
+        if v < 2.0:
+            return 24.3 + v * (100 + v * 16)
+        if v > 3.0:
+            v = 3.0
+        return v * 161.7 - 35.1
 
 
 class K14(Base):
-    '''K14 scale'''
+    """K14 scale"""
+
     def __init__(self):
         Base.__init__(self, "K14", "K14 scale")
         self.add_mark(-200, "")
         self.add_mark(-54, "-40")
-        self.add_mark(-35-14, "")
-        self.add_mark(-30-14, "-30")
-        self.add_mark(-25-14, "")
-        self.add_mark(-20-14, "-20")
-        self.add_mark(-15-14, "")
-        self.add_mark(-10-14, "-10")
-        self.add_mark(-6-14, "-6")
-        self.add_mark(-3-14, "-3")
+        self.add_mark(-35 - 14, "")
+        self.add_mark(-30 - 14, "-30")
+        self.add_mark(-25 - 14, "")
+        self.add_mark(-20 - 14, "-20")
+        self.add_mark(-15 - 14, "")
+        self.add_mark(-10 - 14, "-10")
+        self.add_mark(-6 - 14, "-6")
+        self.add_mark(-3 - 14, "-3")
         self.add_mark(-14, "0")
-        self.add_mark(3-14, "3")
-        self.add_mark(6-14, "6")
-        self.add_mark(10-14, "10")
-        self.add_mark(14-14, "14")
+        self.add_mark(3 - 14, "3")
+        self.add_mark(6 - 14, "6")
+        self.add_mark(10 - 14, "10")
+        self.add_mark(14 - 14, "14")
 
     def db_to_scale(self, db):
-        v = math.pow(10.0, db/20.0)
-        return self.mapk14(v)/448.3
+        v = math.pow(10.0, db / 20.0)
+        return self.mapk14(v) / 448.3
 
     def add_mark(self, db, text):
         self.marks.append(Mark(db, self.db_to_scale(db), text))
 
     def mapk14(self, v):
-        if v < 0.002: return int(12000 * v);
-        v = math.log10(v) + 2.7;
-        if v < 2.0: return int(20.3 + v * (80 + v * 32));
-        if v > 2.7: v = 2.7;
-        return int(v * 200 - 91.7);
+        if v < 0.002:
+            return int(12000 * v)
+        v = math.log10(v) + 2.7
+        if v < 2.0:
+            return int(20.3 + v * (80 + v * 32))
+        if v > 2.7:
+            v = 2.7
+        return int(v * 200 - 91.7)
+
 
 def scale_test1(scale):
     for i in range(-97 * 2, 1, 1):
-        db = float(i)/2.0
+        db = float(i) / 2.0
         print("%5.1f dB maps to %f" % (db, scale.db_to_scale(db)))
 
 
 def scale_test2(scale):
     for i in range(101):
-        s = float(i)/100.0
+        s = float(i) / 100.0
         print("%.2f maps to %.1f dB" % (s, scale.scale_to_db(s)))
 
 
@@ -242,5 +265,5 @@ def _test(*args, **kwargs):
     scale_test3(scale)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _test()

--- a/serialization.py
+++ b/serialization.py
@@ -22,10 +22,11 @@ log = logging.getLogger(__name__)
 
 
 class SerializationBackend:
-    '''Base class for serialization backends'''
+    """Base class for serialization backends"""
+
     def get_root_serialization_object(self, name):
-        '''Returns serialization object where properties of root object
-           will be serialized to'''
+        """Returns serialization object where properties of root object
+        will be serialized to"""
         # this method should never be called for the base class
         raise NotImplementedError
 
@@ -35,10 +36,11 @@ class SerializationBackend:
 
 
 class SerializationObjectBackend:
-    '''Base class for serialization backend objects where real object
-       properties will be serialized to or unserialized from.'''
+    """Base class for serialization backend objects where real object
+    properties will be serialized to or unserialized from."""
+
     def add_property(self, name, value):
-        '''Serialize particular property'''
+        """Serialize particular property"""
         pass
 
     def get_childs(self):
@@ -52,16 +54,17 @@ class SerializationObjectBackend:
 
 
 class SerializedObject:
-    '''Base class for object supporting serialization'''
+    """Base class for object supporting serialization"""
+
     def serialization_name(self):
         return None
 
     def serialize(self, object_backend):
-        '''Serialize properties of called object into supplied serialization_object_backend'''
+        """Serialize properties of called object into supplied serialization_object_backend"""
         pass
 
     def serialization_get_childs(self):
-        '''Get child objects tha required and support serialization'''
+        """Get child objects tha required and support serialization"""
         return []
 
     def unserialize_property(self, name, value):
@@ -76,7 +79,9 @@ class Serializator:
         pass
 
     def serialize(self, root, backend):
-        self.serialize_one(backend, root, backend.get_root_serialization_object(root.serialization_name()))
+        self.serialize_one(
+            backend, root, backend.get_root_serialization_object(root.serialization_name())
+        )
 
     def unserialize(self, root, backend):
         backend_object = backend.get_root_unserialization_object(root.serialization_name())
@@ -109,6 +114,8 @@ class Serializator:
         childs = object.serialization_get_childs()
         for child in childs:
             log.debug("Serializing child %r.", child)
-            self.serialize_one(backend, child,
-                               backend.get_child_serialization_object(
-                                       child.serialization_name(), backend_object))
+            self.serialize_one(
+                backend,
+                child,
+                backend.get_child_serialization_object(child.serialization_name(), backend_object),
+            )

--- a/serialization_xml.py
+++ b/serialization_xml.py
@@ -23,7 +23,9 @@ from serialization import SerializationBackend
 
 class XmlSerialization(SerializationBackend):
     def get_root_serialization_object(self, name):
-        self.doc = xml.dom.getDOMImplementation().createDocument(xml.dom.EMPTY_NAMESPACE, name, None)
+        self.doc = xml.dom.getDOMImplementation().createDocument(
+            xml.dom.EMPTY_NAMESPACE, name, None
+        )
         return XmlSerializationObject(self.doc, self.doc.documentElement)
 
     def get_root_unserialization_object(self, name):
@@ -54,7 +56,7 @@ class XmlSerializationObject:
     def add_property_as_attribute(self, name, value):
         self.element.setAttribute(name, value)
 
-    #def add_property_as_child_element(self, name, value):
+    # def add_property_as_child_element(self, name, value):
     #    child = self.doc.createElement(name)
     #    value = self.doc.createTextNode(value)
     #    child.appendChild(value)

--- a/slider.py
+++ b/slider.py
@@ -48,7 +48,7 @@ class AdjustmentdBFS(Gtk.Adjustment):
     def get_value_db(self):
         return self.db
 
-    def set_value_db(self, db, from_midi = False):
+    def set_value_db(self, db, from_midi=False):
         self.db = db
         self.disable_value_notify = True
         self.set_value(self.scale.db_to_scale(db))
@@ -70,11 +70,21 @@ class AdjustmentdBFS(Gtk.Adjustment):
         self.disable_value_notify = False
 
 
-GObject.signal_new("volume-changed", AdjustmentdBFS,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None, [])
+GObject.signal_new(
+    "volume-changed",
+    AdjustmentdBFS,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [],
+)
 
-GObject.signal_new("volume-changed-from-midi", AdjustmentdBFS,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None, [])
+GObject.signal_new(
+    "volume-changed-from-midi",
+    AdjustmentdBFS,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [],
+)
 
 
 class BalanceAdjustment(Gtk.Adjustment):
@@ -83,7 +93,7 @@ class BalanceAdjustment(Gtk.Adjustment):
         self.connect("value-changed", self.on_value_changed)
         self.disable_value_notify = False
 
-    def set_balance(self, value, from_midi = False):
+    def set_balance(self, value, from_midi=False):
         self.disable_value_notify = True
         self.set_value(value)
         self.disable_value_notify = False
@@ -95,8 +105,13 @@ class BalanceAdjustment(Gtk.Adjustment):
             self.emit("balance-changed")
 
 
-GObject.signal_new("balance-changed", BalanceAdjustment,
-                   GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION, None, [])
+GObject.signal_new(
+    "balance-changed",
+    BalanceAdjustment,
+    GObject.SignalFlags.RUN_FIRST | GObject.SignalFlags.ACTION,
+    None,
+    [],
+)
 
 
 class VolumeSlider(Gtk.Scale):
@@ -110,8 +125,8 @@ class VolumeSlider(Gtk.Scale):
         self.button_down_y = 0
         self.button_down_value = 0
 
-        self.connect('button-press-event', self.button_press_event)
-        self.connect('button-release-event', self.button_release_event)
+        self.connect("button-press-event", self.button_press_event)
+        self.connect("button-release-event", self.button_release_event)
         self.connect("motion-notify-event", self.motion_notify_event)
         self.connect("scroll-event", self.scroll_event)
 
@@ -137,9 +152,8 @@ class VolumeSlider(Gtk.Scale):
         return False
 
     def motion_notify_event(self, widget, event):
-        slider_length = (
-            widget.get_allocation().height -
-            widget.get_style_context().get_property('min-height', Gtk.StateFlags.NORMAL)
+        slider_length = widget.get_allocation().height - widget.get_style_context().get_property(
+            "min-height", Gtk.StateFlags.NORMAL
         )
         if self.button_down:
             delta_y = (self.button_down_y - event.y) / slider_length
@@ -217,9 +231,8 @@ class BalanceSlider(Gtk.Scale):
         return False
 
     def on_motion_notify_event(self, widget, event):
-        slider_length = (
-            widget.get_allocation().width -
-            widget.get_style_context().get_property('min-width', Gtk.StateFlags.NORMAL)
+        slider_length = widget.get_allocation().width - widget.get_style_context().get_property(
+            "min-width", Gtk.StateFlags.NORMAL
         )
 
         if self._button_down:
@@ -265,8 +278,11 @@ class CustomSliderWidget(Gtk.DrawingArea):
         self.connect("button-press-event", self.on_mouse)
         self.connect("motion-notify-event", self.on_mouse)
         self.connect("scroll-event", self.on_scroll)
-        self.set_events(Gdk.EventMask.BUTTON1_MOTION_MASK |
-                        Gdk.EventMask.SCROLL_MASK | Gdk.EventMask.BUTTON_PRESS_MASK)
+        self.set_events(
+            Gdk.EventMask.BUTTON1_MOTION_MASK
+            | Gdk.EventMask.SCROLL_MASK
+            | Gdk.EventMask.BUTTON_PRESS_MASK
+        )
 
     def on_scroll(self, widget, event):
         delta = self.adjustment.step_increment
@@ -286,8 +302,13 @@ class CustomSliderWidget(Gtk.DrawingArea):
         if event.type == Gdk.EventType.BUTTON_PRESS:
             log.debug("Mouse button %u pressed %ux%u", event.button, event.x, event.y)
             if event.button == 1:
-                if event.y >= self.slider_rail_up and event.y < self.slider_rail_up + self.slider_rail_height:
-                    self.adjustment.set_value(1 - float(event.y - self.slider_rail_up) / float(self.slider_rail_height))
+                if (
+                    event.y >= self.slider_rail_up
+                    and event.y < self.slider_rail_up + self.slider_rail_height
+                ):
+                    self.adjustment.set_value(
+                        1 - float(event.y - self.slider_rail_up) / float(self.slider_rail_height)
+                    )
         elif event.type == Gdk.EventType.MOTION_NOTIFY:
             log.debug("Mouse motion %ux%u", event.x, event.y)
             if event.y < self.slider_rail_up:
@@ -296,7 +317,9 @@ class CustomSliderWidget(Gtk.DrawingArea):
                 y = self.slider_rail_up + self.slider_rail_height
             else:
                 y = event.y
-            self.adjustment.set_value(1 - float(y - self.slider_rail_up) / float(self.slider_rail_height))
+            self.adjustment.set_value(
+                1 - float(y - self.slider_rail_up) / float(self.slider_rail_height)
+            )
 
         return False
 
@@ -326,7 +349,7 @@ class CustomSliderWidget(Gtk.DrawingArea):
         requisition.width = 20
 
     def invalidate_all(self):
-        if hasattr(self, 'width') and hasattr(self, 'height'):
+        if hasattr(self, "width") and hasattr(self, "height"):
             self.queue_draw_area(0, 0, int(self.width), int(self.height))
 
     def draw(self, cairo_ctx):
@@ -335,37 +358,40 @@ class CustomSliderWidget(Gtk.DrawingArea):
         else:
             state = Gtk.StateType.NORMAL
 
-        #cairo_ctx.rectangle(0, 0, self.width, self.height)
-        #cairo_ctx.set_source_color(self.style.bg[state])
-        #cairo_ctx.fill_preserve()
-        #Gdk.cairo_set_source_color(cairo_ctx,
+        # cairo_ctx.rectangle(0, 0, self.width, self.height)
+        # cairo_ctx.set_source_color(self.style.bg[state])
+        # cairo_ctx.fill_preserve()
+        # Gdk.cairo_set_source_color(cairo_ctx,
         #        self.get_style_context().get_color(state).to_color())
-        #cairo_ctx.stroke()
+        # cairo_ctx.stroke()
 
         slider_knob_width = 37.5 if self.width * 3 / 4 > 37.5 else self.width * 3 / 4
         slider_knob_height = slider_knob_width * 2
         slider_knob_height -= slider_knob_height % 2
         slider_knob_height += 1
 
-        slider_x = self.width/2
+        slider_x = self.width / 2
 
         cairo_ctx.set_line_width(1)
 
         # slider rail
-        Gdk.cairo_set_source_color(cairo_ctx,
-                self.get_style_context().get_color(state).to_color())
-        self.slider_rail_up = slider_knob_height/2 + (self.width - slider_knob_width)/2
+        Gdk.cairo_set_source_color(cairo_ctx, self.get_style_context().get_color(state).to_color())
+        self.slider_rail_up = slider_knob_height / 2 + (self.width - slider_knob_width) / 2
         self.slider_rail_height = self.height - 2 * self.slider_rail_up
         cairo_ctx.move_to(slider_x, self.slider_rail_up)
         cairo_ctx.line_to(slider_x, self.slider_rail_height + self.slider_rail_up)
         cairo_ctx.stroke()
 
         # slider knob
-        slider_y = round(self.slider_rail_up + self.slider_rail_height * (1 - self.adjustment.get_value()))
-        lg = cairo.LinearGradient(slider_x -
-                float(slider_knob_width)/2, slider_y - slider_knob_height/2,
-                slider_x - float(slider_knob_width)/2, slider_y +
-                slider_knob_height/2)
+        slider_y = round(
+            self.slider_rail_up + self.slider_rail_height * (1 - self.adjustment.get_value())
+        )
+        lg = cairo.LinearGradient(
+            slider_x - float(slider_knob_width) / 2,
+            slider_y - slider_knob_height / 2,
+            slider_x - float(slider_knob_width) / 2,
+            slider_y + slider_knob_height / 2,
+        )
         slider_alpha = 1.0
         lg.add_color_stop_rgba(0, 0.55, 0.55, 0.55, slider_alpha)
         lg.add_color_stop_rgba(0.1, 0.65, 0.65, 0.65, slider_alpha)
@@ -381,12 +407,15 @@ class CustomSliderWidget(Gtk.DrawingArea):
         lg.add_color_stop_rgba(0.900, 0.75, 0.75, 0.75, slider_alpha)
         lg.add_color_stop_rgba(0.900, 0.15, 0.15, 0.15, slider_alpha)
         lg.add_color_stop_rgba(1.000, 0.10, 0.10, 0.10, slider_alpha)
-        cairo_ctx.rectangle(slider_x - float(slider_knob_width)/2,
-                            slider_y - slider_knob_height/2,
-                            float(slider_knob_width),
-                            slider_knob_height)
-        Gdk.cairo_set_source_color(cairo_ctx,
-                self.get_style_context().get_background_color(state).to_color())
+        cairo_ctx.rectangle(
+            slider_x - float(slider_knob_width) / 2,
+            slider_y - slider_knob_height / 2,
+            float(slider_knob_width),
+            slider_knob_height,
+        )
+        Gdk.cairo_set_source_color(
+            cairo_ctx, self.get_style_context().get_background_color(state).to_color()
+        )
         cairo_ctx.fill_preserve()
         cairo_ctx.set_source(lg)
         cairo_ctx.fill()

--- a/styling.py
+++ b/styling.py
@@ -198,9 +198,7 @@ def load_css_styles():
 
 def set_background_color(widget, name, color):
     color_string = color.to_string()
-    add_css_provider(
-        COLOR_TMPL_CSS.format(name, color_string, get_text_color(color))
-    )
+    add_css_provider(COLOR_TMPL_CSS.format(name, color_string, get_text_color(color)))
     widget_context = widget.get_style_context()
     widget_context.add_class(name)
 

--- a/test.py
+++ b/test.py
@@ -3,7 +3,7 @@
 # This file is part of jack_mixer
 #
 # Copyright (C) 2006 Nedko Arnaudov <nedko@arnaudov.name>
-#  
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; version 2 of the License
@@ -31,7 +31,7 @@ else:
 
 channel_name = channel.name
 
-print("%s channel \"%s\"" % (channel_type, channel_name))
+print('%s channel "%s"' % (channel_type, channel_name))
 
 print("Channel meter read %s" % repr(channel.meter))
 print("Channels count: %u" % mixer.channels_count)
@@ -39,4 +39,3 @@ print("Channels count: %u" % mixer.channels_count)
 channel.remove()
 
 print("Channels count: %u" % mixer.channels_count)
-


### PR DESCRIPTION
Rationale: make it easier to spot actual errors in output of flake8.

Also adds configuration for `black` to new `pyproject.toml` file.

`nsmclient.py` is left untouched.

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>