### PR TITLE
Disable processing for kmetering when not using K14/K20 meters

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -25,6 +25,7 @@ from gi.repository import Pango
 
 import abspeak
 import meter
+import scale
 import slider
 from serialization import SerializedObject
 from styling import set_background_color, random_color
@@ -274,6 +275,7 @@ class Channel(Gtk.Box, SerializedObject):
     def on_default_meter_scale_changed(self, gui_factory, scale):
         log.debug("Default meter scale change detected.")
         self.meter.set_scale(scale)
+        self.meter_scale = scale
 
     def on_default_slider_scale_changed(self, gui_factory, scale):
         log.debug("Default slider scale change detected.")
@@ -467,12 +469,17 @@ class Channel(Gtk.Box, SerializedObject):
     def read_meter(self):
         if not self.channel:
             return
+
         if self.stereo:
-            peak_left, peak_right, rms_left, rms_right = self.channel.kmeter
-            self.meter.set_values(peak_left, peak_right, rms_left, rms_right)
+            if self.meter.kmetering:
+                self.meter.set_values_kmeter(*self.channel.kmeter)
+            else:
+                self.meter.set_values(*self.channel.meter)
         else:
-            peak, rms = self.channel.kmeter
-            self.meter.set_values(peak, rms)
+            if self.meter.kmetering:
+                self.meter.set_value_kmeter(*self.channel.kmeter)
+            else:
+                self.meter.set_value(*self.channel.meter)
 
         self.abspeak.set_peak(self.channel.abspeak)
 

--- a/jack_mixer.h
+++ b/jack_mixer.h
@@ -78,6 +78,15 @@ const char*
 get_client_name(
   jack_mixer_t mixer);
 
+bool
+get_kmetering(
+  jack_mixer_t mixer);
+
+void
+set_kmetering(
+  jack_mixer_t mixer,
+  bool flag);
+
 int8_t
 get_last_midi_cc(
   jack_mixer_t mixer);
@@ -150,8 +159,6 @@ channel_mono_kmeter_read(
   jack_mixer_channel_t channel,
   double * mono_ptr,
   double * mono_rms_ptr);
-
-
 
 bool
 channel_is_stereo(

--- a/jack_mixer.py
+++ b/jack_mixer.py
@@ -188,6 +188,9 @@ class JackMixer(SerializedObject):
 
         self.gui_factory = gui.Factory(self.window, self.meter_scales, self.slider_scales)
         self.gui_factory.connect("midi-behavior-mode-changed", self.on_midi_behavior_mode_changed)
+        self.gui_factory.connect(
+            "default-meter-scale-changed", self.on_default_meter_scale_changed
+        )
         self.gui_factory.emit_midi_behavior_mode()
 
         # Recent files manager
@@ -861,6 +864,12 @@ Franklin Street, Fifth Floor, Boston, MA 02110-130159 USA"""
             self.current_filename = None
 
         dlg.destroy()
+
+    def on_default_meter_scale_changed(self, sender, newscale):
+        if isinstance(newscale, (scale.K14, scale.K20)):
+            self.mixer.kmetering = True
+        else:
+            self.mixer.kmetering = False
 
     def read_meters(self):
         for channel in self.channels:

--- a/jack_mixer_c.c
+++ b/jack_mixer_c.c
@@ -311,15 +311,15 @@ Channel_get_kmeter(ChannelObject *self, void *closure)
 	if (channel_is_stereo(self->channel)) {
 		result = PyTuple_New(4);
 		channel_stereo_kmeter_read(self->channel, &peak_left, &peak_right, &rms_left, &rms_right);
-		PyTuple_SetItem(result, 0, PyFloat_FromDouble(peak_left));
-		PyTuple_SetItem(result, 1, PyFloat_FromDouble(peak_right));
-		PyTuple_SetItem(result, 2, PyFloat_FromDouble(rms_left));
-		PyTuple_SetItem(result, 3, PyFloat_FromDouble(rms_right));
+		PyTuple_SetItem(result, 0, PyFloat_FromDouble(rms_left));
+		PyTuple_SetItem(result, 1, PyFloat_FromDouble(rms_right));
+		PyTuple_SetItem(result, 2, PyFloat_FromDouble(peak_left));
+		PyTuple_SetItem(result, 3, PyFloat_FromDouble(peak_right));
 	} else {
 		result = PyTuple_New(2);
 		channel_mono_kmeter_read(self->channel, &peak_left, &rms_left);
-		PyTuple_SetItem(result, 0, PyFloat_FromDouble(peak_left));
-		PyTuple_SetItem(result, 1, PyFloat_FromDouble(rms_left));
+		PyTuple_SetItem(result, 0, PyFloat_FromDouble(rms_left));
+		PyTuple_SetItem(result, 1, PyFloat_FromDouble(peak_left));
 	}
 	return result;
 }
@@ -994,6 +994,31 @@ Mixer_get_client_name(MixerObject *self, void *closure)
 }
 
 static PyObject*
+Mixer_get_kmetering(MixerObject *self, void *closure)
+{
+	PyObject *result;
+
+	if (get_kmetering(self->mixer)) {
+		result = Py_True;
+	} else {
+		result = Py_False;
+	}
+	Py_INCREF(result);
+	return result;
+}
+
+static int
+Mixer_set_kmetering(MixerObject *self, PyObject *value, void *closure)
+{
+	if (value == Py_True) {
+		set_kmetering(self->mixer, true);
+	} else {
+		set_kmetering(self->mixer, false);
+	}
+	return 0;
+}
+
+static PyObject*
 Mixer_get_last_midi_cc(MixerObject *self, void *closure)
 {
 	return PyLong_FromLong(get_last_midi_cc(self->mixer));
@@ -1038,6 +1063,8 @@ Mixer_set_midi_behavior_mode(MixerObject *self, PyObject *value, void *closure)
 static PyGetSetDef Mixer_getseters[] = {
 	{"channels_count", (getter)Mixer_get_channels_count, NULL,
 		"channels count", NULL},
+	{"kmetering", (getter)Mixer_get_kmetering, (setter)Mixer_set_kmetering,
+		"k-metering", NULL},
 	{"last_midi_cc", (getter)Mixer_get_last_midi_cc, (setter)Mixer_set_last_midi_cc,
 		"last midi channel", NULL},
 	{"midi_behavior_mode", (getter)Mixer_get_midi_behavior_mode, (setter)Mixer_set_midi_behavior_mode,


### PR DESCRIPTION
Also draw the other meter scales again the way they were drawn before K14/K20 scales were added and without peak markers
