### PR TITLE
Add support for meson dist command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,3 +59,10 @@ endif
 if get_option('gui').enabled() and not get_option('wheel')
     meson.add_install_script('meson_postinstall.py')
 endif
+
+summary({
+    'Build jack_mixer GUI': get_option('gui').enabled(),
+    'JACK MIDI support': get_option('jack-midi').enabled(),
+    'Debug messages (verbose)': get_option('verbose'),
+    'Build for wheel': get_option('wheel'),
+}, section: 'Configuration')

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,17 +24,24 @@ executable(
 
 # Generate extension module C source from Cython sources
 if get_option('gui').enabled()
-    cython = find_program('cython')
-
     jack_mixer_mod_pyx = '_jack_mixer.pyx'
-    jack_mixer_mod_pxd = '_jack_mixer.pxd'
     jack_mixer_mod_c = '_jack_mixer.c'
 
-    jack_mixer_cython = custom_target(
-        'jack_mixer_cython',
-        output: jack_mixer_mod_c,
-        input: jack_mixer_mod_pyx,
-        depend_files: [jack_mixer_mod_pyx, jack_mixer_mod_pxd],
-        command: [cython, '-o', '@OUTPUT@', '@INPUT@'],
-    )
+    cython = find_program('cython', required: false)
+
+    if cython.found()
+        jack_mixer_mod_pxd = '_jack_mixer.pxd'
+
+        jack_mixer_cython = custom_target(
+            'jack_mixer_cython',
+            output: jack_mixer_mod_c,
+            input: jack_mixer_mod_pyx,
+            depend_files: [jack_mixer_mod_pyx, jack_mixer_mod_pxd],
+            command: [cython, '-o', '@OUTPUT@', '@INPUT@'],
+        )
+    else
+        jack_mixer_cython = files(jack_mixer_mod_c)
+    endif
+
+    meson.add_dist_script('meson_dist_cython.py', jack_mixer_mod_pyx)
 endif

--- a/src/meson_dist_cython.py
+++ b/src/meson_dist_cython.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+from os import environ, getcwd
+from os.path import exists, join, splitext
+
+from subprocess import run
+
+build_root = environ.get("MESON_BUILD_ROOT")
+dist_root = environ.get("MESON_DIST_ROOT")
+source_root = environ.get("MESON_SOURCE_ROOT")
+
+ap = argparse.ArgumentParser()
+ap.add_argument('-v', '--verbose', action="store_true", help="Be more verbose.")
+ap.add_argument('pyx', nargs="*", help="Cython source files (*.pyx).")
+args = ap.parse_args()
+
+if args.verbose:
+    print("cwd:", getcwd())
+    print("build root:", build_root)
+    print("dist root:", dist_root)
+    print("source root:", source_root)
+    print("sys.argv:", sys.argv)
+
+for pyx in args.pyx:
+    src = join(source_root, 'src', pyx)
+    dst = join(dist_root, "src", splitext(pyx)[0] + '.c')
+
+    if exists(src):
+        print("Cythonizing source file '%s'..." % src)
+        print("Output file: '%s'" % dst)
+        cmd = ["cython"]
+
+        if args.verbose:
+            cmd += ["-v"]
+
+        cmd += ["-o", dst, src]
+        try:
+            proc = run(cmd)
+
+            if proc.returncode != 0:
+                sys.exit("cython returned non-zero (%i) for '%s'." %
+                         (proc.returncode, pyx))
+        except FileNotFoundError:
+            sys.exit("The 'cython' program was not found but is required to build a "
+                     "distribution.\nPlease install Cython from: "
+                     "https://pypi.org/project/Cython/")


### PR DESCRIPTION
* Add dist script, which compiles Cython source files to be included in the source distribution.
* Make Cython build dependency optional for when source tree already contains the C sources compiled from the Cython source files.
* Print build configuration options when setting up build.
