### PR TITLE
Add i18n support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,5 +8,6 @@ extend-exclude =
     dist,
     nsmclient.py
 per-file-ignores =
-    # import not at top of file due to gi.require_version
+    # import not at top of file due to gi.require_version and i18n
     app.py: E402
+builtins = _

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ _jack_mixer.*.so
 
 # recommended meson build directory
 builddir/
+
+# i18n
+data/locale/*/LC_MESSAGES/
+data/locale/*.po~

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ Build requirements:
  * Python headers
  * [JACK] headers
  * glib2 headers
+ * gettext
  * [Cython] (optional, required if building from a Git checkout)
  * [docutils] (optional, `rst2man` required if building from a Git checkout)
 

--- a/data/locale/jack_mixer-de.po
+++ b/data/locale/jack_mixer-de.po
@@ -1,0 +1,684 @@
+# #-#-#-#-#  jack_mixer-de.po (jack_mixer 15.1)  #-#-#-#-#
+# jack_mixer i18n message catalog template
+#
+# This file is distributed under the same license as the jack_mixer package.
+#
+# Copyright (C) 2021 Christopher Arndt <chris@chrisarndt.de>
+#
+# #-#-#-#-#  argparse-de.po (argparse Python 3.9)  #-#-#-#-#
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: jack_mixer 15.1\n"
+"Report-Msgid-Bugs-To: https://github.com/jack-mixer/jack_mixer/issues\n"
+"POT-Creation-Date: 2021-03-18 17:32+0100\n"
+"PO-Revision-Date: 2021-03-20 14:27+0100\n"
+"Last-Translator: Christopher Arndt <chris@chrisarndt.de>\n"
+"Language-Team: https://github.com/jack-mixer/jack_mixer\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: jack_mixer/app.py:48 jack_mixer/app.py:47
+msgid ""
+"jack_mixer is free software; you can redistribute it and/or modify it\n"
+"under the terms of the GNU General Public License as published by the\n"
+"Free Software Foundation; either version 2 of the License, or (at your\n"
+"option) any later version.\n"
+"\n"
+"jack_mixer is distributed in the hope that it will be useful, but\n"
+"WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n"
+"General Public License for more details.\n"
+"\n"
+"You should have received a copy of the GNU General Public License along\n"
+"with jack_mixer; if not, write to the Free Software Foundation, Inc., 51\n"
+"Franklin Street, Fifth Floor, Boston, MA 02110-130159 USA\n"
+msgstr ""
+
+#: jack_mixer/app.py:118 jack_mixer/app.py:121
+msgid "Failed to create Mixer instance."
+msgstr "Erstellen einer Mixer-Instanz fehlgeschlagen"
+
+# Don't translate this unless you want the monitor JACK output port name to be localized
+#: jack_mixer/app.py:123 jack_mixer/app.py:126
+msgid "Monitor"
+msgstr ""
+
+#: jack_mixer/app.py:165 jack_mixer/app.py:168
+msgid "jack_mixer XML files"
+msgstr "jack_mixer XML-Dateien"
+
+#: jack_mixer/app.py:178 jack_mixer/app.py:181
+msgid "_Recent Projects"
+msgstr "_Zuletzt geöffnet"
+
+#: jack_mixer/app.py:212 jack_mixer/app.py:215
+msgid "_Mixer"
+msgstr "_Mixer"
+
+#: jack_mixer/app.py:214 jack_mixer/app.py:217
+msgid "_Edit"
+msgstr "_Bearbeiten"
+
+#: jack_mixer/app.py:216 jack_mixer/app.py:219
+msgid "_Help"
+msgstr "_Hilfe"
+
+#: jack_mixer/app.py:224 jack_mixer/app.py:227
+msgid "New _Input Channel"
+msgstr "Neuer _Eingangskanal"
+
+#: jack_mixer/app.py:228 jack_mixer/app.py:231
+msgid "New Output _Channel"
+msgstr "Neuer _Ausgangskanal"
+
+#: jack_mixer/app.py:235 jack_mixer/app.py:238
+msgid "_Open..."
+msgstr "Ö_ffnen..."
+
+#: jack_mixer/app.py:241 jack_mixer/app.py:244
+msgid "_Save"
+msgstr "_Speichern"
+
+#: jack_mixer/app.py:245 jack_mixer/app.py:248
+msgid "Save _As..."
+msgstr "Speichern _unter..."
+
+#: jack_mixer/app.py:250 jack_mixer/app.py:253
+msgid "_Hide"
+msgstr "Aus_blenden"
+
+#: jack_mixer/app.py:252 jack_mixer/app.py:255
+msgid "_Quit"
+msgstr "_Beenden"
+
+#: jack_mixer/app.py:259 jack_mixer/app.py:262
+msgid "_Edit Input Channel"
+msgstr "_Eingangskanal ändern"
+
+#: jack_mixer/app.py:266 jack_mixer/app.py:269
+msgid "E_dit Output Channel"
+msgstr "_Ausgangskanal ändern"
+
+#: jack_mixer/app.py:273 jack_mixer/app.py:276
+msgid "_Remove Input Channel"
+msgstr "Eingangskanal entfe_rnen"
+
+#: jack_mixer/app.py:280 jack_mixer/app.py:283
+msgid "Re_move Output Channel"
+msgstr "Ausgangskanal e_ntfernen"
+
+#: jack_mixer/app.py:288 jack_mixer/app.py:291
+msgid "Shrink Channels"
+msgstr "Kanäle ver_kleinern"
+
+#: jack_mixer/app.py:291 jack_mixer/app.py:294
+msgid "Expand Channels"
+msgstr "Kanäle verbreitern"
+
+#: jack_mixer/app.py:295 jack_mixer/app.py:298
+msgid "_Clear"
+msgstr "A_lle entfernen"
+
+#: jack_mixer/app.py:300 jack_mixer/app.py:303
+msgid "_Preferences"
+msgstr "Ein_stellungen"
+
+#: jack_mixer/app.py:307 jack_mixer/app.py:310
+msgid "_About"
+msgstr "Ü_ber"
+
+#: jack_mixer/app.py:357 jack_mixer/app.py:360
+msgid "Input channel creation failed."
+msgstr "Erstellen des Eingangskanals fehlgeschlagen"
+
+#: jack_mixer/app.py:416 jack_mixer/app.py:419
+msgid "Output channel creation failed."
+msgstr "Erstellen des Ausgangskanals fehlgeschlagen"
+
+#: jack_mixer/app.py:475 jack_mixer/app.py:557 jack_mixer/app.py:1138
+#: jack_mixer/app.py:478 jack_mixer/app.py:560 jack_mixer/app.py:1144
+#, python-brace-format
+msgid "Error loading project file '{filename}': {msg}"
+msgstr "Projektdatei '{filename}' konnte nicht geladen werden: {msg}"
+
+#: jack_mixer/app.py:542 jack_mixer/app.py:545
+msgid "XML files"
+msgstr "XML-Dateien"
+
+#: jack_mixer/app.py:546 jack_mixer/app.py:549
+msgid "All files"
+msgstr "Alle Dateien"
+
+#: jack_mixer/app.py:567 jack_mixer/app.py:570
+msgid "Open project"
+msgstr "Projekt öffnen"
+
+#: jack_mixer/app.py:615 jack_mixer/app.py:658 jack_mixer/app.py:618
+#: jack_mixer/app.py:661
+#, python-brace-format
+msgid "Error saving project file '{filename}': {msg}"
+msgstr "Projektdatei '{filename}' konnte nicht gespeichert werden: {msg}"
+
+#: jack_mixer/app.py:622 jack_mixer/app.py:625
+msgid "Save project"
+msgstr "Projekt speichern"
+
+#: jack_mixer/app.py:675 jack_mixer/app.py:678
+msgid "<b>Quit application?</b>"
+msgstr "<b>Programm beenden?</b>"
+
+#: jack_mixer/app.py:678 jack_mixer/app.py:681
+msgid ""
+"All jack_mixer ports will be closed and connections lost,\n"
+"stopping all sound going through jack_mixer.\n"
+"\n"
+"Are you sure?"
+msgstr ""
+"Alle Ein- und Ausgänge von jack_mixer werden geschlossen, alle\n"
+"Verbindungen gehen verloren und der Signalfluss durch jack_mixer wird "
+"gestoppt.\n"
+"\n"
+"Sind Sie sicher?"
+
+# Don't translate this unless you want default channel names to be localized
+#: jack_mixer/app.py:743 jack_mixer/app.py:746
+msgid "Input"
+msgstr ""
+
+# Don't translate this unless you want default channel names to be localized
+#: jack_mixer/app.py:746 jack_mixer/app.py:749
+msgid "Output"
+msgstr ""
+
+#: jack_mixer/app.py:874 jack_mixer/app.py:877
+msgid "Are you sure you want to clear all channels?"
+msgstr "Wollen Sie wirklich alle Kanäle entfernen?"
+
+#: jack_mixer/app.py:1103 jack_mixer/app.py:1109
+msgid "load mixer project configuration from FILE"
+msgstr "Mixerprojektkonfiguration aus DATEI laden"
+
+#: jack_mixer/app.py:1110 jack_mixer/app.py:1116
+msgid "enable debug logging messages"
+msgstr "Debug-Logmeldungen aktivieren"
+
+#: jack_mixer/app.py:1128 jack_mixer/app.py:1134
+msgid ""
+"Mixer creation failed:\n"
+"\n"
+"{}"
+msgstr ""
+"Erstellen einer Mixer-Instanz fehlgeschlagen:\n"
+"\n"
+"{}"
+
+# msgid "Error loading project file '{filename}': {msg}"
+# msgstr "Projektdatei '{filename}' konnte nicht geladen werden: {msg}"
+# Don't translate this unless you want JACK output port names to be localized
+#: jack_mixer/channel.py:90
+#, python-brace-format
+msgid "{channel_name} Out"
+msgstr "{channel_name} Out"
+
+#: jack_mixer/channel.py:113 jack_mixer/channel.py:1329
+msgid "M"
+msgstr "M"
+
+#: jack_mixer/channel.py:122
+msgid "MON"
+msgstr "MON"
+
+#: jack_mixer/channel.py:569
+msgid "S"
+msgstr "S"
+
+#: jack_mixer/channel.py:580
+msgid "Cannot create a channel"
+msgstr "Erzeugung eines Kanals fehlgeschlagen"
+
+#: jack_mixer/channel.py:795
+msgid "Cannot create an output channel"
+msgstr "Erzeugung eines Ausgangkanals fehlgeschlagen"
+
+#: jack_mixer/channel.py:940
+#, python-brace-format
+msgid "Channel '{name}' Properties"
+msgstr "Eigenschaften von Kanal '{name}'"
+
+#: jack_mixer/channel.py:981
+msgid "Properties"
+msgstr "Eigenschaften"
+
+#: jack_mixer/channel.py:986
+msgid "_Name"
+msgstr "_Name"
+
+#: jack_mixer/channel.py:995
+msgid "Mode"
+msgstr "Modus"
+
+#: jack_mixer/channel.py:996
+msgid "_Mono"
+msgstr "_Mono"
+
+#: jack_mixer/channel.py:997
+msgid "_Stereo"
+msgstr "_Stereo"
+
+#: jack_mixer/channel.py:1002
+msgid "MIDI Control Changes"
+msgstr "MIDI Control Changes"
+
+#: jack_mixer/channel.py:1008
+#, python-brace-format
+msgid ""
+"{param} MIDI Control Change number (0-127, set to -1 to assign next free CC "
+"#)"
+msgstr ""
+"MIDI Control Change Nummer für {param} (0-127, auf -1 setzen, um nächste "
+"freie CC# zuzuweisen)"
+
+#: jack_mixer/channel.py:1010
+msgid "_Volume"
+msgstr "_Lautstärke"
+
+#: jack_mixer/channel.py:1014
+msgid "Volume"
+msgstr "Lautstärke"
+
+#: jack_mixer/channel.py:1017 jack_mixer/channel.py:1028
+#: jack_mixer/channel.py:1039 jack_mixer/channel.py:1064
+msgid "Learn"
+msgstr "Lerne"
+
+#: jack_mixer/channel.py:1021
+msgid "_Balance"
+msgstr "_Balance"
+
+#: jack_mixer/channel.py:1025
+msgid "Balance"
+msgstr "Balance"
+
+#: jack_mixer/channel.py:1032
+msgid "M_ute"
+msgstr "St_umm"
+
+#: jack_mixer/channel.py:1036
+msgid "Mute"
+msgstr "Stumm"
+
+#: jack_mixer/channel.py:1046
+msgid "_Direct Out(s)"
+msgstr "Direktausgänge"
+
+#: jack_mixer/channel.py:1051
+msgid "Add direct post-fader output(s) for channel."
+msgstr "Kanal hat direkte(n) post-fader Ausgang/-gänge"
+
+#: jack_mixer/channel.py:1057
+msgid "S_olo"
+msgstr "S_olo"
+
+#: jack_mixer/channel.py:1061
+msgid "Solo"
+msgstr "Solo"
+
+#: jack_mixer/channel.py:1098
+msgid "Please move the MIDI control you want to use for this function."
+msgstr ""
+"Bitte bewegen Sie das MIDI-Kontrollelement, dass Sie dieser Funktion "
+"zuweisen wollen."
+
+#: jack_mixer/channel.py:1101
+#, fuzzy
+msgid "This window will close in 5 seconds."
+msgstr "Dieses Fenster schließt in 5 Sekunden."
+
+#: jack_mixer/channel.py:1107
+#, python-brace-format
+msgid "This window will close in {seconds} seconds."
+msgstr "Dieses Fenster schließt in {seconds} Sekunden."
+
+#: jack_mixer/channel.py:1188
+msgid "Value"
+msgstr "Initialwert"
+
+#: jack_mixer/channel.py:1189
+msgid "-_Inf"
+msgstr "-_Inf"
+
+#: jack_mixer/channel.py:1190
+msgid "_0dB"
+msgstr "_0dB"
+
+#: jack_mixer/channel.py:1197
+msgid "New Input Channel"
+msgstr "Neuer Eingangskanal"
+
+#: jack_mixer/channel.py:1230
+msgid "_Color"
+msgstr "_Farbe"
+
+#: jack_mixer/channel.py:1239
+msgid "Input Channels"
+msgstr "Eingangskanäle"
+
+#: jack_mixer/channel.py:1241
+msgid "_Display solo buttons"
+msgstr "Solo-Schalter anzeigen"
+
+#: jack_mixer/channel.py:1263
+msgid "New Output Channel"
+msgstr "Neuer Ausgangskanal"
+
+#: jack_mixer/channel.py:1331
+msgid "Mute output channel send"
+msgstr "Sendeweg zum Ausgangskanal stummschalten"
+
+#: jack_mixer/channel.py:1337
+msgid "Solo output send"
+msgstr "Sendeweg zum Ausgangskanal auf Solo schalten"
+
+#: jack_mixer/channel.py:1341
+msgid "P"
+msgstr "P"
+
+#: jack_mixer/channel.py:1343
+msgid "Pre (on) / Post (off) fader send"
+msgstr "Prä (ein) / Post-Fader"
+
+#: jack_mixer/gui.py:63
+msgid "Cannot load PyXDG. "
+msgstr "Kann PyXDG nicht laden. "
+
+#: jack_mixer/gui.py:64
+msgid "Your preferences will not be preserved across jack_mixer invocations"
+msgstr ""
+"Ihre globalen Einstellungen bleiben nicht erhalten wenn jack_mixer beendet "
+"wird"
+
+#: jack_mixer/preferences.py:30
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: jack_mixer/preferences.py:56 jack_mixer/preferences.py:68
+msgid "Default Project Path"
+msgstr "Standardprojektpfad"
+
+#: jack_mixer/preferences.py:71
+msgid "Confirm quit"
+msgstr "Beenden bestätigen"
+
+#: jack_mixer/preferences.py:73
+msgid "Always ask for confirmation before quitting the application"
+msgstr "Das Beenden des Programms muss immer bestätigt werden"
+
+#: jack_mixer/preferences.py:79
+msgid "Use custom widgets"
+msgstr "Angepasste Kontrollelemente verwenden"
+
+#: jack_mixer/preferences.py:84
+msgid "Use custom vumeter color"
+msgstr "Festgelegte Farbe für Pegelanzeige verwenden"
+
+#: jack_mixer/preferences.py:95
+msgid "Custom color:"
+msgstr "Farbe"
+
+#: jack_mixer/preferences.py:103
+msgid "Interface"
+msgstr "Benutzerschnittstelle"
+
+#: jack_mixer/preferences.py:109
+msgid "Meter scale"
+msgstr "Meterskala"
+
+#: jack_mixer/preferences.py:113
+msgid "Slider scale"
+msgstr "Schieberskala"
+
+#: jack_mixer/preferences.py:117
+msgid "Scales"
+msgstr "Skalen"
+
+#: jack_mixer/preferences.py:123
+msgid "Control Behavior"
+msgstr "Kontrollverhalten"
+
+#: jack_mixer/preferences.py:127
+msgid "MIDI"
+msgstr "MIDI"
+
+#: jack_mixer/scale.py:88
+msgid ""
+"IEC 60268-18 Peak programme level meters - Digital audio peak level meter"
+msgstr "IEC 60268-18 Aussteuerungsmesser - Digitaler Audio-Spitzenpegelmesser"
+
+#: jack_mixer/scale.py:115
+msgid ""
+"IEC 60268-18 Peak programme level meters - Digital audio peak level meter, "
+"fewer marks"
+msgstr ""
+"IEC 60268-18 Aussteuerungsmesser - Digitaler Audio-Spitzenpegelmesser mit "
+"weniger Eichmarken"
+
+#: jack_mixer/scale.py:135
+msgid "Linear scale with range from -70 to 0 dBFS"
+msgstr "Lineare Skala mit einem Bereich von -70 bis 0 dbFS"
+
+#: jack_mixer/scale.py:156
+msgid "Linear scale with range from -30 to +30 dBFS"
+msgstr "Lineare Skala mit einem Bereich von -30 bis +30 dBFS"
+
+#: jack_mixer/scale.py:167
+msgid "K20 scale"
+msgstr "K20 Skala"
+
+#: jack_mixer/scale.py:207
+msgid "K14 scale"
+msgstr "K14 Skala"
+
+#: jack_mixer/serialization_xml.py:58
+#, python-brace-format
+msgid "Document type '{type}' not supported."
+msgstr "Dokumententyp '{type}' wird nicht unterstützt."
+
+#: jack_mixer/slider.py:249
+msgid "Center"
+msgstr "Mitte"
+
+#: jack_mixer/slider.py:252
+#, python-brace-format
+msgid "Left: {left} / Right: {right}"
+msgstr "Links: {left} / Rechts: {right}"
+
+#: jack_mixer/app.py:1103 jack_mixer/app.py:1108
+msgid "FILE"
+msgstr "DATEI"
+
+#: jack_mixer/app.py:1114 jack_mixer/app.py:1120
+msgid "NAME"
+msgstr "NAME"
+
+#: jack_mixer/app.py:46
+msgid ""
+"A multi-channel audio mixer application for the JACK Audio Connection Kit."
+msgstr "Eine Mehrkanalaudiomixeranwendung für das JACK Audio Connection Kit."
+
+#: jack_mixer/app.py:1123
+#, python-format
+msgid "set JACK client name (default: %(default)s)"
+msgstr "Setze Namen des JACK-Klienten (Standard: %(default)s)"
+
+#: jack_mixer/gui.py:141
+#, fuzzy, python-format
+msgid "Ignoring default_meter_scale setting, because '%s' scale is not known."
+msgstr ""
+"Die Einstellung für default_meter_scale wird ignoriert, da die Skala '%s' "
+"unbekannt ist."
+
+#: jack_mixer/gui.py:158
+#, fuzzy, python-format
+msgid "Ignoring default_slider_scale setting, because '%s' scale is not known."
+msgstr ""
+"Die Einstellung für default_slider_scale wird ignoriert, da die Skala '%s' "
+"unbekannt ist."
+
+#: /usr/lib/python3.9/argparse.py:296
+msgid "usage: "
+msgstr "Benutzung: "
+
+#: /usr/lib/python3.9/argparse.py:854
+msgid ".__call__() not defined"
+msgstr ".__call__() ist nicht definiert"
+
+#: /usr/lib/python3.9/argparse.py:1197
+#, python-format
+msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
+msgstr "unbekannter Parser %(parser_name)r (Auswahl: %(choices)s)"
+
+#: /usr/lib/python3.9/argparse.py:1257
+#, python-format
+msgid "argument \"-\" with mode %r"
+msgstr "Argument \"-\" in Kombination mit Modus %r"
+
+#: /usr/lib/python3.9/argparse.py:1266
+#, python-format
+msgid "can't open '%(filename)s': %(error)s"
+msgstr "Kann '%(filename)s' nicht öffnen: %(error)s"
+
+#: /usr/lib/python3.9/argparse.py:1475
+#, python-format
+msgid "cannot merge actions - two groups are named %r"
+msgstr "Kann die Aktionen nicht zusammenführen - es git zwei Gruppen namens %r"
+
+#: /usr/lib/python3.9/argparse.py:1513
+msgid "'required' is an invalid argument for positionals"
+msgstr "'required' ist als Argument für positionale Argumente nicht gültig"
+
+#: /usr/lib/python3.9/argparse.py:1535
+#, python-format
+msgid ""
+"invalid option string %(option)r: must start with a character "
+"%(prefix_chars)r"
+msgstr ""
+"ungültiger Optionsbezeichner %(option)r: muss mit einem %(prefix_chars)r "
+"anfangen"
+
+#: /usr/lib/python3.9/argparse.py:1553
+#, python-format
+msgid "dest= is required for options like %r"
+msgstr "dest= ist für Optionen der Art %r notwendig"
+
+#: /usr/lib/python3.9/argparse.py:1570
+#, python-format
+msgid "invalid conflict_resolution value: %r"
+msgstr "ungültiger Wert für conflict_resolution: %r"
+
+#: /usr/lib/python3.9/argparse.py:1588
+#, python-format
+msgid "conflicting option string: %s"
+msgid_plural "conflicting option strings: %s"
+msgstr[0] "Konflikt mit Optionsbezeichner: %s"
+msgstr[1] "Konflikt mit Optionsbezeichnern: %s"
+
+#: /usr/lib/python3.9/argparse.py:1654
+msgid "mutually exclusive arguments must be optional"
+msgstr "Sich gegenseitig auschließende Argumente müssen optional sein"
+
+#: /usr/lib/python3.9/argparse.py:1721
+msgid "positional arguments"
+msgstr "Positionsargumente"
+
+#: /usr/lib/python3.9/argparse.py:1722
+msgid "optional arguments"
+msgstr "Optionale Argumente"
+
+#: /usr/lib/python3.9/argparse.py:1737
+msgid "show this help message and exit"
+msgstr "Diese Hilfe anzeigen und beenden"
+
+#: /usr/lib/python3.9/argparse.py:1768
+msgid "cannot have multiple subparser arguments"
+msgstr "mehrere subparser Argumente sind nicht erlaubt"
+
+#: /usr/lib/python3.9/argparse.py:1820 /usr/lib/python3.9/argparse.py:2331
+#, python-format
+msgid "unrecognized arguments: %s"
+msgstr "Nicht erkannte Argumente: %s"
+
+#: /usr/lib/python3.9/argparse.py:1921
+#, python-format
+msgid "not allowed with argument %s"
+msgstr "ist in Kombination mit Argument %s nicht erlaubt"
+
+#: /usr/lib/python3.9/argparse.py:1967 /usr/lib/python3.9/argparse.py:1981
+#, python-format
+msgid "ignored explicit argument %r"
+msgstr "das explizite Argument %r wurde ignoriert"
+
+#: /usr/lib/python3.9/argparse.py:2088
+#, python-format
+msgid "the following arguments are required: %s"
+msgstr "Die folgenden Argument sind erforderlich: %s"
+
+#: /usr/lib/python3.9/argparse.py:2103
+#, python-format
+msgid "one of the arguments %s is required"
+msgstr "eins der Argumente %s wird erwartet"
+
+#: /usr/lib/python3.9/argparse.py:2146
+msgid "expected one argument"
+msgstr "ein Argument erwartet"
+
+#: /usr/lib/python3.9/argparse.py:2147
+msgid "expected at most one argument"
+msgstr "höchstens ein Argument erwartet"
+
+#: /usr/lib/python3.9/argparse.py:2148
+msgid "expected at least one argument"
+msgstr "mindestens ein Argument erwartet"
+
+#: /usr/lib/python3.9/argparse.py:2152
+#, python-format
+msgid "expected %s argument"
+msgid_plural "expected %s arguments"
+msgstr[0] "%s Argument erwartet"
+msgstr[1] "%s Argumente erwartet"
+
+#: /usr/lib/python3.9/argparse.py:2210
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr "mehrdeutige Option: konnte %(option)s nicht zu %(matches)s zuordnen"
+
+#: /usr/lib/python3.9/argparse.py:2274
+#, python-format
+msgid "unexpected option string: %s"
+msgstr "unerwarteter Optionsbezeichner: %s"
+
+#: /usr/lib/python3.9/argparse.py:2471
+#, python-format
+msgid "%r is not callable"
+msgstr "%r ist nicht aufrufbar"
+
+#: /usr/lib/python3.9/argparse.py:2488
+#, python-format
+msgid "invalid %(type)s value: %(value)r"
+msgstr "ungültiger Wert für %(type)s: %(value)r"
+
+#: /usr/lib/python3.9/argparse.py:2499
+#, python-format
+msgid "invalid choice: %(value)r (choose from %(choices)s)"
+msgstr "ungültige Auswahl: %(value)r (wähle aus %(choices)s)"
+
+#: /usr/lib/python3.9/argparse.py:2575
+#, python-format
+msgid "%(prog)s: error: %(message)s\n"
+msgstr "%(prog)s: Fehler: %(message)s\n"

--- a/data/locale/jack_mixer.pot
+++ b/data/locale/jack_mixer.pot
@@ -1,0 +1,654 @@
+# jack_mixer i18n message catalog template
+#
+# This file is distributed under the same license as the jack_mixer package.
+#
+# Copyright (C) 2021 Christopher Arndt <chris@chrisarndt.de>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: jack_mixer 15.1\n"
+"Report-Msgid-Bugs-To: https://github.com/jack-mixer/jack_mixer/issues\n"
+"POT-Creation-Date: 2021-03-20 14:48+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: jack_mixer/app.py:48 jack_mixer/app.py:47 jack_mixer/app.py:49
+msgid ""
+"jack_mixer is free software; you can redistribute it and/or modify it\n"
+"under the terms of the GNU General Public License as published by the\n"
+"Free Software Foundation; either version 2 of the License, or (at your\n"
+"option) any later version.\n"
+"\n"
+"jack_mixer is distributed in the hope that it will be useful, but\n"
+"WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n"
+"General Public License for more details.\n"
+"\n"
+"You should have received a copy of the GNU General Public License along\n"
+"with jack_mixer; if not, write to the Free Software Foundation, Inc., 51\n"
+"Franklin Street, Fifth Floor, Boston, MA 02110-130159 USA\n"
+msgstr ""
+
+#: jack_mixer/app.py:118 jack_mixer/app.py:121 jack_mixer/app.py:122
+msgid "Failed to create Mixer instance."
+msgstr ""
+
+# Don't translate this unless you want the monitor JACK output port name to be localized
+#: jack_mixer/app.py:123 jack_mixer/app.py:126 jack_mixer/app.py:127
+msgid "Monitor"
+msgstr ""
+
+#: jack_mixer/app.py:165 jack_mixer/app.py:168 jack_mixer/app.py:169
+msgid "jack_mixer XML files"
+msgstr ""
+
+#: jack_mixer/app.py:178 jack_mixer/app.py:181 jack_mixer/app.py:182
+msgid "_Recent Projects"
+msgstr ""
+
+#: jack_mixer/app.py:212 jack_mixer/app.py:215 jack_mixer/app.py:216
+msgid "_Mixer"
+msgstr ""
+
+#: jack_mixer/app.py:214 jack_mixer/app.py:217 jack_mixer/app.py:218
+msgid "_Edit"
+msgstr ""
+
+#: jack_mixer/app.py:216 jack_mixer/app.py:219 jack_mixer/app.py:220
+msgid "_Help"
+msgstr ""
+
+#: jack_mixer/app.py:224 jack_mixer/app.py:227 jack_mixer/app.py:228
+msgid "New _Input Channel"
+msgstr ""
+
+#: jack_mixer/app.py:228 jack_mixer/app.py:231 jack_mixer/app.py:232
+msgid "New Output _Channel"
+msgstr ""
+
+#: jack_mixer/app.py:235 jack_mixer/app.py:238 jack_mixer/app.py:239
+msgid "_Open..."
+msgstr ""
+
+#: jack_mixer/app.py:241 jack_mixer/app.py:244 jack_mixer/app.py:245
+msgid "_Save"
+msgstr ""
+
+#: jack_mixer/app.py:245 jack_mixer/app.py:248 jack_mixer/app.py:249
+msgid "Save _As..."
+msgstr ""
+
+#: jack_mixer/app.py:250 jack_mixer/app.py:253 jack_mixer/app.py:254
+msgid "_Hide"
+msgstr ""
+
+#: jack_mixer/app.py:252 jack_mixer/app.py:255 jack_mixer/app.py:256
+msgid "_Quit"
+msgstr ""
+
+#: jack_mixer/app.py:259 jack_mixer/app.py:262 jack_mixer/app.py:263
+msgid "_Edit Input Channel"
+msgstr ""
+
+#: jack_mixer/app.py:266 jack_mixer/app.py:269 jack_mixer/app.py:270
+msgid "E_dit Output Channel"
+msgstr ""
+
+#: jack_mixer/app.py:273 jack_mixer/app.py:276 jack_mixer/app.py:277
+msgid "_Remove Input Channel"
+msgstr ""
+
+#: jack_mixer/app.py:280 jack_mixer/app.py:283 jack_mixer/app.py:284
+msgid "Re_move Output Channel"
+msgstr ""
+
+#: jack_mixer/app.py:288 jack_mixer/app.py:291 jack_mixer/app.py:292
+msgid "Shrink Channels"
+msgstr ""
+
+#: jack_mixer/app.py:291 jack_mixer/app.py:294 jack_mixer/app.py:295
+msgid "Expand Channels"
+msgstr ""
+
+#: jack_mixer/app.py:295 jack_mixer/app.py:298 jack_mixer/app.py:299
+msgid "_Clear"
+msgstr ""
+
+#: jack_mixer/app.py:300 jack_mixer/app.py:303 jack_mixer/app.py:304
+msgid "_Preferences"
+msgstr ""
+
+#: jack_mixer/app.py:307 jack_mixer/app.py:310 jack_mixer/app.py:311
+msgid "_About"
+msgstr ""
+
+#: jack_mixer/app.py:357 jack_mixer/app.py:360 jack_mixer/app.py:361
+msgid "Input channel creation failed."
+msgstr ""
+
+#: jack_mixer/app.py:416 jack_mixer/app.py:419 jack_mixer/app.py:420
+msgid "Output channel creation failed."
+msgstr ""
+
+#: jack_mixer/app.py:475 jack_mixer/app.py:557 jack_mixer/app.py:1138
+#: jack_mixer/app.py:478 jack_mixer/app.py:560 jack_mixer/app.py:1144
+#: jack_mixer/app.py:479 jack_mixer/app.py:561 jack_mixer/app.py:1145
+#, python-brace-format
+msgid "Error loading project file '{filename}': {msg}"
+msgstr ""
+
+#: jack_mixer/app.py:542 jack_mixer/app.py:545 jack_mixer/app.py:546
+msgid "XML files"
+msgstr ""
+
+#: jack_mixer/app.py:546 jack_mixer/app.py:549 jack_mixer/app.py:550
+msgid "All files"
+msgstr ""
+
+#: jack_mixer/app.py:567 jack_mixer/app.py:570 jack_mixer/app.py:571
+msgid "Open project"
+msgstr ""
+
+#: jack_mixer/app.py:615 jack_mixer/app.py:658 jack_mixer/app.py:618
+#: jack_mixer/app.py:661 jack_mixer/app.py:619 jack_mixer/app.py:662
+#, python-brace-format
+msgid "Error saving project file '{filename}': {msg}"
+msgstr ""
+
+#: jack_mixer/app.py:622 jack_mixer/app.py:625 jack_mixer/app.py:626
+msgid "Save project"
+msgstr ""
+
+#: jack_mixer/app.py:675 jack_mixer/app.py:678 jack_mixer/app.py:679
+msgid "<b>Quit application?</b>"
+msgstr ""
+
+#: jack_mixer/app.py:678 jack_mixer/app.py:681 jack_mixer/app.py:682
+msgid ""
+"All jack_mixer ports will be closed and connections lost,\n"
+"stopping all sound going through jack_mixer.\n"
+"\n"
+"Are you sure?"
+msgstr ""
+
+# Don't translate this unless you want default channel names to be localized
+#: jack_mixer/app.py:743 jack_mixer/app.py:746 jack_mixer/app.py:747
+msgid "Input"
+msgstr ""
+
+# Don't translate this unless you want default channel names to be localized
+#: jack_mixer/app.py:746 jack_mixer/app.py:749 jack_mixer/app.py:750
+msgid "Output"
+msgstr ""
+
+#: jack_mixer/app.py:874 jack_mixer/app.py:877 jack_mixer/app.py:878
+msgid "Are you sure you want to clear all channels?"
+msgstr ""
+
+#: jack_mixer/app.py:1103 jack_mixer/app.py:1109 jack_mixer/app.py:1110
+msgid "load mixer project configuration from FILE"
+msgstr ""
+
+#: jack_mixer/app.py:1110 jack_mixer/app.py:1116 jack_mixer/app.py:1117
+msgid "enable debug logging messages"
+msgstr ""
+
+#: jack_mixer/app.py:1128 jack_mixer/app.py:1134 jack_mixer/app.py:1135
+msgid ""
+"Mixer creation failed:\n"
+"\n"
+"{}"
+msgstr ""
+
+# Don't translate this unless you want JACK output port names to be localized
+#: jack_mixer/channel.py:90
+#, python-brace-format
+msgid "{channel_name} Out"
+msgstr ""
+
+#: jack_mixer/channel.py:113 jack_mixer/channel.py:1329
+msgid "M"
+msgstr ""
+
+#: jack_mixer/channel.py:122
+msgid "MON"
+msgstr ""
+
+#: jack_mixer/channel.py:569
+msgid "S"
+msgstr ""
+
+#: jack_mixer/channel.py:580
+msgid "Cannot create a channel"
+msgstr ""
+
+#: jack_mixer/channel.py:795
+msgid "Cannot create an output channel"
+msgstr ""
+
+#: jack_mixer/channel.py:940
+#, python-brace-format
+msgid "Channel '{name}' Properties"
+msgstr ""
+
+#: jack_mixer/channel.py:981
+msgid "Properties"
+msgstr ""
+
+#: jack_mixer/channel.py:986
+msgid "_Name"
+msgstr ""
+
+#: jack_mixer/channel.py:995
+msgid "Mode"
+msgstr ""
+
+#: jack_mixer/channel.py:996
+msgid "_Mono"
+msgstr ""
+
+#: jack_mixer/channel.py:997
+msgid "_Stereo"
+msgstr ""
+
+#: jack_mixer/channel.py:1002
+msgid "MIDI Control Changes"
+msgstr ""
+
+#: jack_mixer/channel.py:1008
+#, python-brace-format
+msgid ""
+"{param} MIDI Control Change number (0-127, set to -1 to assign next free CC "
+"#)"
+msgstr ""
+
+#: jack_mixer/channel.py:1010
+msgid "_Volume"
+msgstr ""
+
+#: jack_mixer/channel.py:1014
+msgid "Volume"
+msgstr ""
+
+#: jack_mixer/channel.py:1017 jack_mixer/channel.py:1028
+#: jack_mixer/channel.py:1039 jack_mixer/channel.py:1064
+msgid "Learn"
+msgstr ""
+
+#: jack_mixer/channel.py:1021
+msgid "_Balance"
+msgstr ""
+
+#: jack_mixer/channel.py:1025
+msgid "Balance"
+msgstr ""
+
+#: jack_mixer/channel.py:1032
+msgid "M_ute"
+msgstr ""
+
+#: jack_mixer/channel.py:1036
+msgid "Mute"
+msgstr ""
+
+#: jack_mixer/channel.py:1046
+msgid "_Direct Out(s)"
+msgstr ""
+
+#: jack_mixer/channel.py:1051
+msgid "Add direct post-fader output(s) for channel."
+msgstr ""
+
+#: jack_mixer/channel.py:1057
+msgid "S_olo"
+msgstr ""
+
+#: jack_mixer/channel.py:1061
+msgid "Solo"
+msgstr ""
+
+#: jack_mixer/channel.py:1098
+msgid "Please move the MIDI control you want to use for this function."
+msgstr ""
+
+#: jack_mixer/channel.py:1101
+msgid "This window will close in 5 seconds."
+msgstr ""
+
+#: jack_mixer/channel.py:1107
+#, python-brace-format
+msgid "This window will close in {seconds} seconds."
+msgstr ""
+
+#: jack_mixer/channel.py:1188
+msgid "Value"
+msgstr ""
+
+#: jack_mixer/channel.py:1189
+msgid "-_Inf"
+msgstr ""
+
+#: jack_mixer/channel.py:1190
+msgid "_0dB"
+msgstr ""
+
+#: jack_mixer/channel.py:1197
+msgid "New Input Channel"
+msgstr ""
+
+#: jack_mixer/channel.py:1230
+msgid "_Color"
+msgstr ""
+
+#: jack_mixer/channel.py:1239
+msgid "Input Channels"
+msgstr ""
+
+#: jack_mixer/channel.py:1241
+msgid "_Display solo buttons"
+msgstr ""
+
+#: jack_mixer/channel.py:1263
+msgid "New Output Channel"
+msgstr ""
+
+#: jack_mixer/channel.py:1331
+msgid "Mute output channel send"
+msgstr ""
+
+#: jack_mixer/channel.py:1337
+msgid "Solo output send"
+msgstr ""
+
+#: jack_mixer/channel.py:1341
+msgid "P"
+msgstr ""
+
+#: jack_mixer/channel.py:1343
+msgid "Pre (on) / Post (off) fader send"
+msgstr ""
+
+#: jack_mixer/gui.py:63
+msgid "Cannot load PyXDG. "
+msgstr ""
+
+#: jack_mixer/gui.py:64
+msgid "Your preferences will not be preserved across jack_mixer invocations"
+msgstr ""
+
+#: jack_mixer/preferences.py:30
+msgid "Preferences"
+msgstr ""
+
+#: jack_mixer/preferences.py:56 jack_mixer/preferences.py:68
+msgid "Default Project Path"
+msgstr ""
+
+#: jack_mixer/preferences.py:71
+msgid "Confirm quit"
+msgstr ""
+
+#: jack_mixer/preferences.py:73
+msgid "Always ask for confirmation before quitting the application"
+msgstr ""
+
+#: jack_mixer/preferences.py:79
+msgid "Use custom widgets"
+msgstr ""
+
+#: jack_mixer/preferences.py:84
+msgid "Use custom vumeter color"
+msgstr ""
+
+#: jack_mixer/preferences.py:95
+msgid "Custom color:"
+msgstr ""
+
+#: jack_mixer/preferences.py:103
+msgid "Interface"
+msgstr ""
+
+#: jack_mixer/preferences.py:109
+msgid "Meter scale"
+msgstr ""
+
+#: jack_mixer/preferences.py:113
+msgid "Slider scale"
+msgstr ""
+
+#: jack_mixer/preferences.py:117
+msgid "Scales"
+msgstr ""
+
+#: jack_mixer/preferences.py:123
+msgid "Control Behavior"
+msgstr ""
+
+#: jack_mixer/preferences.py:127
+msgid "MIDI"
+msgstr ""
+
+#: jack_mixer/scale.py:88
+msgid ""
+"IEC 60268-18 Peak programme level meters - Digital audio peak level meter"
+msgstr ""
+
+#: jack_mixer/scale.py:115
+msgid ""
+"IEC 60268-18 Peak programme level meters - Digital audio peak level meter, "
+"fewer marks"
+msgstr ""
+
+#: jack_mixer/scale.py:135
+msgid "Linear scale with range from -70 to 0 dBFS"
+msgstr ""
+
+#: jack_mixer/scale.py:156
+msgid "Linear scale with range from -30 to +30 dBFS"
+msgstr ""
+
+#: jack_mixer/scale.py:167
+msgid "K20 scale"
+msgstr ""
+
+#: jack_mixer/scale.py:207
+msgid "K14 scale"
+msgstr ""
+
+#: jack_mixer/serialization_xml.py:58
+#, python-brace-format
+msgid "Document type '{type}' not supported."
+msgstr ""
+
+#: jack_mixer/slider.py:249
+msgid "Center"
+msgstr ""
+
+#: jack_mixer/slider.py:252
+#, python-brace-format
+msgid "Left: {left} / Right: {right}"
+msgstr ""
+
+#: jack_mixer/app.py:1103 jack_mixer/app.py:1108 jack_mixer/app.py:1109
+msgid "FILE"
+msgstr ""
+
+#: jack_mixer/app.py:1114 jack_mixer/app.py:1120 jack_mixer/app.py:1121
+msgid "NAME"
+msgstr ""
+
+#: jack_mixer/app.py:46 jack_mixer/app.py:48
+msgid ""
+"A multi-channel audio mixer application for the JACK Audio Connection Kit."
+msgstr ""
+
+#: jack_mixer/app.py:1123 jack_mixer/app.py:1124
+#, python-format
+msgid "set JACK client name (default: %(default)s)"
+msgstr ""
+
+#: jack_mixer/gui.py:141
+#, python-format
+msgid "Ignoring default_meter_scale setting, because '%s' scale is not known."
+msgstr ""
+
+#: jack_mixer/gui.py:158
+#, python-format
+msgid "Ignoring default_slider_scale setting, because '%s' scale is not known."
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:296
+msgid "usage: "
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:854
+msgid ".__call__() not defined"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1197
+#, python-format
+msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1257
+#, python-format
+msgid "argument \"-\" with mode %r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1266
+#, python-format
+msgid "can't open '%(filename)s': %(error)s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1475
+#, python-format
+msgid "cannot merge actions - two groups are named %r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1513
+msgid "'required' is an invalid argument for positionals"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1535
+#, python-format
+msgid ""
+"invalid option string %(option)r: must start with a character "
+"%(prefix_chars)r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1553
+#, python-format
+msgid "dest= is required for options like %r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1570
+#, python-format
+msgid "invalid conflict_resolution value: %r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1588
+#, python-format
+msgid "conflicting option string: %s"
+msgid_plural "conflicting option strings: %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /usr/lib/python3.9/argparse.py:1654
+msgid "mutually exclusive arguments must be optional"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1721
+msgid "positional arguments"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1722
+msgid "optional arguments"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1737
+msgid "show this help message and exit"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1768
+msgid "cannot have multiple subparser arguments"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1820 /usr/lib/python3.9/argparse.py:2331
+#, python-format
+msgid "unrecognized arguments: %s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1921
+#, python-format
+msgid "not allowed with argument %s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:1967 /usr/lib/python3.9/argparse.py:1981
+#, python-format
+msgid "ignored explicit argument %r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2088
+#, python-format
+msgid "the following arguments are required: %s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2103
+#, python-format
+msgid "one of the arguments %s is required"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2146
+msgid "expected one argument"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2147
+msgid "expected at most one argument"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2148
+msgid "expected at least one argument"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2152
+#, python-format
+msgid "expected %s argument"
+msgid_plural "expected %s arguments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /usr/lib/python3.9/argparse.py:2210
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2274
+#, python-format
+msgid "unexpected option string: %s"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2471
+#, python-format
+msgid "%r is not callable"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2488
+#, python-format
+msgid "invalid %(type)s value: %(value)r"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2499
+#, python-format
+msgid "invalid choice: %(value)r (choose from %(choices)s)"
+msgstr ""
+
+#: /usr/lib/python3.9/argparse.py:2575
+#, python-format
+msgid "%(prog)s: error: %(message)s\n"
+msgstr ""

--- a/data/locale/meson.build
+++ b/data/locale/meson.build
@@ -1,0 +1,19 @@
+if get_option('gui').enabled()
+    languages = ['de']
+    msgfmt = find_program('msgfmt')
+
+    foreach lang : languages
+        target = meson.project_name() + '-' + lang
+        po_file = target + '.po'
+        mo_file = meson.project_name() + '.mo'
+        msg_dir = join_paths(get_option('localedir'), lang, 'LC_MESSAGES')
+        dist_mo = join_paths('data', 'lang', 'LC_MESSAGES', mo_file)
+
+        mo = configure_file(
+            input: po_file,
+            output: target + '.mo',
+            command: [msgfmt, '-o', '@OUTPUT@', '@INPUT@'],
+        )
+        install_data(mo, rename: mo_file, install_dir: msg_dir)
+    endforeach
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -25,3 +25,6 @@ install_data(
     join_paths('art', 'scalable', 'jack_mixer.svg'),
     install_dir: join_paths(icondir, 'scalable', 'apps')
 )
+
+# Translations
+subdir('locale')

--- a/jack_mixer/abspeak.py
+++ b/jack_mixer/abspeak.py
@@ -57,6 +57,7 @@ class AbspeakWidget(Gtk.EventBox):
             context.add_class("is_nan")
             self.label.set_text("NaN")
         else:
+            # TODO: l10n
             text = "%+.1f" % peak
             context.remove_class("is_nan")
 

--- a/jack_mixer/gui.py
+++ b/jack_mixer/gui.py
@@ -60,8 +60,8 @@ class Factory(GObject.GObject, SerializedObject):
                 self.write_preferences()
         else:
             log.warning(
-                "Cannot load PyXDG. Your preferences will not be preserved across "
-                "jack_mixer invocations"
+                _("Cannot load PyXDG. ")
+                + _("Your preferences will not be preserved across jack_mixer invocations")
             )
 
     def set_default_preferences(self):
@@ -138,7 +138,7 @@ class Factory(GObject.GObject, SerializedObject):
             self.emit("default-meter-scale-changed", self.default_meter_scale)
         else:
             log.warning(
-                'Ignoring default_meter_scale setting, because "%s" scale is not known.', scale
+                _("Ignoring default_meter_scale setting, because '%s' scale is not known."), scale
             )
 
     def set_default_project_path(self, path):
@@ -155,7 +155,7 @@ class Factory(GObject.GObject, SerializedObject):
             self.emit("default-slider-scale-changed", self.default_slider_scale)
         else:
             log.warning(
-                'Ignoring default_slider_scale setting, because "%s" scale is not known.', scale
+                _("Ignoring default_slider_scale setting, because '%s' scale is not known."), scale
             )
 
     def set_midi_behavior_mode(self, mode):

--- a/jack_mixer/preferences.py
+++ b/jack_mixer/preferences.py
@@ -27,7 +27,7 @@ class PreferencesDialog(Gtk.Dialog):
     def __init__(self, parent):
         self.app = parent
         GObject.GObject.__init__(self)
-        self.set_title("Preferences")
+        self.set_title(_("Preferences"))
         self.create_ui()
         self.connect("response", self.on_response_cb)
         self.connect("delete-event", self.on_response_cb)
@@ -53,7 +53,7 @@ class PreferencesDialog(Gtk.Dialog):
         self.path_entry.connect("changed", self.on_path_entry_changed)
         path_vbox.pack_start(self.path_entry, False, False, 3)
         self.project_path_chooser = Gtk.FileChooserButton(
-            title="Default Project Path", action=Gtk.FileChooserAction.SELECT_FOLDER
+            title=_("Default Project Path"), action=Gtk.FileChooserAction.SELECT_FOLDER
         )
         project_path = self.app.gui_factory.default_project_path
         path_vbox.pack_start(self.project_path_chooser, False, False, 3)
@@ -65,23 +65,23 @@ class PreferencesDialog(Gtk.Dialog):
                 self.project_path_chooser.set_current_folder(expanduser(project_path))
 
         self.project_path_chooser.connect("file-set", self.on_project_path_selected)
-        vbox.pack_start(self.create_frame("Default Project Path", path_vbox), True, True, 0)
+        vbox.pack_start(self.create_frame(_("Default Project Path"), path_vbox), True, True, 0)
 
         interface_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.confirm_quit_checkbutton = Gtk.CheckButton("Confirm quit")
+        self.confirm_quit_checkbutton = Gtk.CheckButton(_("Confirm quit"))
         self.confirm_quit_checkbutton.set_tooltip_text(
-            "Always ask for confirmation before " "quitting the application"
+            _("Always ask for confirmation before quitting the application")
         )
         self.confirm_quit_checkbutton.set_active(self.app.gui_factory.get_confirm_quit())
         self.confirm_quit_checkbutton.connect("toggled", self.on_confirm_quit_toggled)
         interface_vbox.pack_start(self.confirm_quit_checkbutton, True, True, 3)
 
-        self.custom_widgets_checkbutton = Gtk.CheckButton("Use custom widgets")
+        self.custom_widgets_checkbutton = Gtk.CheckButton(_("Use custom widgets"))
         self.custom_widgets_checkbutton.set_active(self.app.gui_factory.get_use_custom_widgets())
         self.custom_widgets_checkbutton.connect("toggled", self.on_custom_widget_toggled)
         interface_vbox.pack_start(self.custom_widgets_checkbutton, True, True, 3)
 
-        self.vumeter_color_checkbutton = Gtk.CheckButton("Use custom vumeter color")
+        self.vumeter_color_checkbutton = Gtk.CheckButton(_("Use custom vumeter color"))
         self.vumeter_color_checkbutton.set_active(
             self.app.gui_factory.get_vumeter_color_scheme() == "solid"
         )
@@ -92,7 +92,7 @@ class PreferencesDialog(Gtk.Dialog):
         interface_vbox.pack_start(hbox, True, True, 3)
 
         hbox.set_sensitive(self.vumeter_color_checkbutton.get_active())
-        hbox.pack_start(Gtk.Label("Custom color:"), False, True, 5)
+        hbox.pack_start(Gtk.Label(_("Custom color:")), False, True, 5)
         self.vumeter_color_picker = Gtk.ColorButton()
         self.vumeter_color_picker.set_color(
             Gdk.color_parse(self.app.gui_factory.get_vumeter_color())
@@ -100,31 +100,31 @@ class PreferencesDialog(Gtk.Dialog):
         self.vumeter_color_picker.connect("color-set", self.on_vumeter_color_change)
         hbox.pack_start(self.vumeter_color_picker, True, True, 0)
 
-        vbox.pack_start(self.create_frame("Interface", interface_vbox), True, True, 0)
+        vbox.pack_start(self.create_frame(_("Interface"), interface_vbox), True, True, 0)
 
         table = Gtk.Table(2, 2, False)
         table.set_row_spacings(5)
         table.set_col_spacings(5)
 
-        table.attach(Gtk.Label(label="Meter scale"), 0, 1, 0, 1)
+        table.attach(Gtk.Label(label=_("Meter scale")), 0, 1, 0, 1)
         self.meter_scale_combo = self.create_meter_store_and_combo()
         table.attach(self.meter_scale_combo, 1, 2, 0, 1)
 
-        table.attach(Gtk.Label(label="Slider scale"), 0, 1, 1, 2)
+        table.attach(Gtk.Label(label=_("Slider scale")), 0, 1, 1, 2)
         self.slider_scale_combo = self.create_slider_store_and_combo()
         table.attach(self.slider_scale_combo, 1, 2, 1, 2)
 
-        vbox.pack_start(self.create_frame("Scales", table), True, True, 0)
+        vbox.pack_start(self.create_frame(_("Scales"), table), True, True, 0)
 
         table = Gtk.Table(1, 2, False)
         table.set_row_spacings(5)
         table.set_col_spacings(5)
 
-        table.attach(Gtk.Label(label="Control Behavior"), 0, 1, 0, 1)
+        table.attach(Gtk.Label(label=_("Control Behavior")), 0, 1, 0, 1)
         self.midi_behavior_combo = self.create_midi_behavior_combo()
         table.attach(self.midi_behavior_combo, 1, 2, 0, 1)
 
-        vbox.pack_start(self.create_frame("MIDI", table), True, True, 0)
+        vbox.pack_start(self.create_frame(_("MIDI"), table), True, True, 0)
         self.vbox.show_all()
 
         self.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE)

--- a/jack_mixer/scale.py
+++ b/jack_mixer/scale.py
@@ -31,6 +31,7 @@ class Mark:
         self.db = db
         self.scale = scale
         if text is None:
+            # TODO: l10n
             self.text = "%.0f" % math.fabs(db)
         else:
             self.text = text
@@ -84,7 +85,7 @@ class IEC268(Base):
         Base.__init__(
             self,
             "iec_268",
-            "IEC 60268-18 Peak programme level meters - Digital audio peak level meter",
+            _("IEC 60268-18 Peak programme level meters - Digital audio peak level meter"),
         )
         self.add_threshold(-70.0, 0.0, False)
         self.add_threshold(-60.0, 0.05, True)
@@ -110,8 +111,10 @@ class IEC268Minimalistic(Base):
         Base.__init__(
             self,
             "iec_268_minimalistic",
-            "IEC 60268-18 Peak programme level meters - "
-            "Digital audio peak level meter, fewer marks",
+            _(
+                "IEC 60268-18 Peak programme level meters - "
+                "Digital audio peak level meter, fewer marks"
+            ),
         )
         self.add_threshold(-70.0, 0.0, False)
         self.add_threshold(-60.0, 0.05, True)
@@ -129,7 +132,7 @@ class Linear70dB(Base):
     """Linear scale with range from -70 to 0 dBFS"""
 
     def __init__(self):
-        Base.__init__(self, "linear_70dB", "Linear scale with range from -70 to 0 dBFS")
+        Base.__init__(self, "linear_70dB", _("Linear scale with range from -70 to 0 dBFS"))
         self.add_threshold(-70.0, 0.0, False)
         self.add_mark(-60.0)
         self.add_mark(-50.0)
@@ -150,7 +153,7 @@ class Linear30dB(Base):
     """Linear scale with range from -30 to +30 dBFS"""
 
     def __init__(self):
-        Base.__init__(self, "linear_30dB", "Linear scale with range from -30 to +30 dBFS")
+        Base.__init__(self, "linear_30dB", _("Linear scale with range from -30 to +30 dBFS"))
         self.add_threshold(-30.0, 0.0, False)
         self.add_threshold(+30.0, 1.0, True)
         self.calculate_coefficients()
@@ -161,7 +164,7 @@ class K20(Base):
     """K20 scale"""
 
     def __init__(self):
-        Base.__init__(self, "K20", "K20 scale")
+        Base.__init__(self, "K20", _("K20 scale"))
         self.add_mark(-200, "")
         self.add_mark(-60, "-40")
         self.add_mark(-55, "")
@@ -201,7 +204,7 @@ class K14(Base):
     """K14 scale"""
 
     def __init__(self):
-        Base.__init__(self, "K14", "K14 scale")
+        Base.__init__(self, "K14", _("K14 scale"))
         self.add_mark(-200, "")
         self.add_mark(-54, "-40")
         self.add_mark(-35 - 14, "")

--- a/jack_mixer/serialization_xml.py
+++ b/jack_mixer/serialization_xml.py
@@ -54,7 +54,9 @@ class XmlSerialization(SerializationBackend):
 
         document_type = self.doc.documentElement.nodeName
         if document_type != name:
-            raise InvalidDocumentTypeError("Document type '%s' not supported." % document_type)
+            raise InvalidDocumentTypeError(
+                _("Document type '{type}' not supported.").format(type=document_type)
+            )
 
 
 class XmlSerializationObject:

--- a/jack_mixer/slider.py
+++ b/jack_mixer/slider.py
@@ -246,9 +246,11 @@ class BalanceSlider(Gtk.Scale):
     def on_query_tooltip(self, widget, x, y, keyboard_mode, tooltip, *args):
         val = int(self.adjustment.get_value() * 50)
         if val == 0:
-            tooltip.set_text("Center")
+            tooltip.set_text(_("Center"))
         else:
-            tooltip.set_text("Left: %s / Right: %d" % (50 - val, val + 50))
+            tooltip.set_text(
+                _("Left: {left} / Right: {right}").format(left=50 - val, right=val + 50)
+            )
 
         return True
 

--- a/tools/compile-messages.py
+++ b/tools/compile-messages.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Compile translated message catalog *.po files to *.mo with msgfmt."""
+
+import glob
+import os
+from os.path import basename, join, splitext
+from subprocess import run
+
+LOCALEDIR = join(os.getcwd(), "data", "locale")
+
+for po in glob.glob(join(LOCALEDIR, "*.po")):
+    fn = basename(po)
+    domain, lang = splitext(fn)[0].rsplit("-", 1)
+    langdir = join(LOCALEDIR, lang, "LC_MESSAGES")
+    mo = join(langdir, domain + ".mo")
+    print(f"Compiling {fn} to {mo} ...")
+    os.makedirs(langdir, exist_ok=True)
+    run(["msgfmt", "-o", mo, po])

--- a/tools/extract-messages.sh
+++ b/tools/extract-messages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+LOCALEDIR="$(pwd)/data/locale"
+POT="$LOCALEDIR/jack_mixer.pot"
+VERSION="$(grep -A 5 project meson.build | grep version | cut -d "'" -f 2)"
+ARGPARSE_PY="$(python -c 'import argparse; print(argparse.__file__)')"
+
+echo "Extracting translatable messages from argparse and jack_mixer/*.py to $POT."
+exec xgettext \
+    --package-name=jack_mixer \
+    "--package-version=$VERSION" \
+    "--msgid-bugs-address=https://github.com/jack-mixer/jack_mixer/issues" \
+    --from-code=utf-8 \
+    --join-existing \
+    -o "$POT" \
+    jack_mixer/*.py \
+    "$ARGPARSE_PY"

--- a/tools/jack_mixer.sh
+++ b/tools/jack_mixer.sh
@@ -3,9 +3,11 @@
 if ! ls -a jack_mixer/_jack_mixer.*.so >/dev/null 2>&1 ; then
     echo "'_jack_mixer' extension module not found."
     echo "This script is meant to be run from a jack_mixer source directory"
-    echo "Make sure that you have built jack_mixer with meson."
+    echo "Make sure that you have built jack_mixer with meson and created"
+    echo "the language translation files with ./tools/compile-messages.py."
     exit 1
 fi
 
 export PYTHONPATH=".:$PYTHONPATH"
+export LOCALEDIR="data/locale"
 exec python -m jack_mixer "$@"

--- a/tools/merge-messages.py
+++ b/tools/merge-messages.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Merge new/updated messages from jack_mixer.pot into existing translations with msgmerge."""
+
+import glob
+import os
+from os.path import basename, join, splitext
+from subprocess import run
+
+LOCALEDIR = join(os.getcwd(), "data", "locale")
+
+for po in glob.glob(join(LOCALEDIR, "*.po")):
+    fn = basename(po)
+    domain, lang = splitext(fn)[0].rsplit("-", 1)
+    pot = join(LOCALEDIR, domain + ".pot")
+    print(f"Merging new/updated messages from {pot} into {po} ...")
+    run(["msgmerge", "-U", po, pot])


### PR DESCRIPTION
* Add gettext support and mark translatable strings
* Add i18n message catalog *.pot template for translatable strings
  in jack_mixer's Python sources and the stdlib argparse module.
* Add German messages translation for the above.
* Add helper scripts for managing i18n files
* Add support for compiling & installing translation files to
  meson build setup.
* Add gettext to list of build dependencies in `INSTALL.md`.