### PR TITLE
Replace PyXDG module with appdirs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ Runtime requirements:
 
 Optional run-time dependencies:
 
-* [pyxdg] (for saving your preferences, strongly recommended)
+* [appdirs] (for saving your preferences, strongly recommended)
 * [NSM] (for NSM session management support)
 
 The run-time Python dependencies are checked by meson when setting up the

--- a/data/locale/jack_mixer-de.po
+++ b/data/locale/jack_mixer-de.po
@@ -400,8 +400,8 @@ msgid "Use system setting"
 msgstr "Systemeinstellung benutzen"
 
 #: jack_mixer/gui.py:70
-msgid "Cannot load PyXDG. "
-msgstr "Kann PyXDG nicht laden. "
+msgid "Cannot load appdirs. "
+msgstr "Kann appdirs nicht laden. "
 
 #: jack_mixer/gui.py:71
 msgid "Your preferences will not be preserved across jack_mixer invocations."

--- a/data/locale/jack_mixer-es.po
+++ b/data/locale/jack_mixer-es.po
@@ -411,8 +411,8 @@ msgid "Use system setting"
 msgstr "Utilizar configuración del sistema"
 
 #: jack_mixer/gui.py:70
-msgid "Cannot load PyXDG. "
-msgstr "No se pudo cargar PyXDG. "
+msgid "Cannot load appdirs. "
+msgstr "No se pudo cargar appdirs. "
 
 #: jack_mixer/gui.py:71
 msgid "Your preferences will not be preserved across jack_mixer invocations."

--- a/data/locale/jack_mixer-fr.po
+++ b/data/locale/jack_mixer-fr.po
@@ -392,8 +392,8 @@ msgid "Use system setting"
 msgstr "Utiliser le paramètre système"
 
 #: jack_mixer/gui.py:69
-msgid "Cannot load PyXDG. "
-msgstr "Impossible de charger PyXDG."
+msgid "Cannot load appdirs. "
+msgstr "Impossible de charger appdirs."
 
 #: jack_mixer/gui.py:70
 msgid "Your preferences will not be preserved across jack_mixer invocations."

--- a/data/locale/jack_mixer.pot
+++ b/data/locale/jack_mixer.pot
@@ -385,7 +385,7 @@ msgid "Use system setting"
 msgstr ""
 
 #: jack_mixer/gui.py:70
-msgid "Cannot load PyXDG. "
+msgid "Cannot load appdirs. "
 msgstr ""
 
 #: jack_mixer/gui.py:71

--- a/jack_mixer/gui.py
+++ b/jack_mixer/gui.py
@@ -23,10 +23,13 @@ import gi  # noqa: F401
 from gi.repository import GObject
 
 try:
-    import xdg
-    from xdg import BaseDirectory
+    import appdirs
+
+    confdir = appdirs.user_config_dir("jack_mixer")
+    datadir = appdirs.user_data_dir("jack_mixer")
 except ImportError:
-    xdg = None
+    confdir = None
+    datadir = None
 
 from .serialization import SerializedObject
 
@@ -56,18 +59,17 @@ class Factory(GObject.GObject, SerializedObject):
         self.meter_scales = meter_scales
         self.slider_scales = slider_scales
         self.set_default_preferences()
-        if xdg:
+        if confdir:
+            os.makedirs(confdir, exist_ok=True)
             self.config = configparser.ConfigParser()
-            self.path = os.path.join(
-                BaseDirectory.save_config_path("jack_mixer"), "preferences.ini"
-            )
+            self.path = os.path.join(confdir, "preferences.ini")
             if os.path.isfile(self.path):
                 self.read_preferences()
             else:
                 self.write_preferences()
         else:
             log.warning(
-                _("Cannot load PyXDG. ")
+                _("Cannot load appdirs. ")
                 + _("Your preferences will not be preserved across jack_mixer invocations.")
             )
 
@@ -217,8 +219,9 @@ class Factory(GObject.GObject, SerializedObject):
     def get_default_project_path(self):
         if self.default_project_path:
             return os.path.expanduser(self.default_project_path)
-        elif xdg:
-            return BaseDirectory.save_data_path("jack_mixer")
+        elif datadir:
+            os.makedirs(datadir, exist_ok=True)
+            return datadir
 
     def get_default_slider_scale(self):
         return self.default_slider_scale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ project-urls = [
 requires= [
     "PyGObject",
     "pycairo",
-    "pyxdg",
+    "appdirs",
 ]
 requires-python = ">=3.6"
 classifiers = [


### PR DESCRIPTION
`appdirs` returns appropriate platform-specific directories for saving user
preferences and data.