### PR TITLE
Prefix all log messages in C and Python with [jack_mixer] and unify/add newlines after log messages

### DIFF
--- a/jack_mixer/app.py
+++ b/jack_mixer/app.py
@@ -1200,7 +1200,7 @@ def main():
     args = parser.parse_args()
 
     logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO, format="%(levelname)s: %(message)s"
+        level=logging.DEBUG if args.debug else logging.INFO, format="[{}] %(levelname)s: %(message)s".format(__program__)
     )
 
     try:

--- a/jack_mixer/nsmclient.py
+++ b/jack_mixer/nsmclient.py
@@ -4,12 +4,12 @@
 PyNSMClient -  A New Session Manager Client-Library in one file.
 
 The Non-Session-Manager by Jonathan Moore Liles <male@tuxfamily.org>: http://non.tuxfamily.org/nsm/
-New Session Manager, by LinuxAudio.org: https://new-session-manager.jackaudio.org/
+New Session Manager by Nils Hilbricht et al  https://new-session-manager.jackaudio.org
 With help from code fragments from https://github.com/attwad/python-osc ( DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE v2 )
 
 MIT License
 
-Copyright 2014-2020 Nils Hilbricht https://www.laborejo.org
+Copyright (c) since 2014: Laborejo Software Suite <info@laborejo.org>, All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -28,7 +28,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 """
 
 import logging;
-logger = None #filled by init with prettyName
+logger: logging.Logger  #filled by init with client logger.
 
 import struct
 import socket
@@ -387,7 +387,8 @@ class NSMClient(object):
         else:
             #osc.udp://hostname:portnumber/
             o = urlparse(nsmOSCUrl)
-            return o.hostname, o.port
+            #return o.hostname, o.port #this always make the hostname lowercase. usually it does not matter, but we got crash reports. Alternative:
+            return o.netloc.split(":")[0], o.port
 
     def getExecutableName(self):
         """Finding the actual executable name can be a bit hard

--- a/src/jack_mixer.c
+++ b/src/jack_mixer.c
@@ -192,7 +192,7 @@ interpolate(
 {
   double ret;
   double frac = 0.01;
-  LOG_DEBUG("Interpolation: start=%f -> end=%f, step=%d\n", start, end, step);
+  LOG_DEBUG("Interpolation: start=%f -> end=%f, step=%d", start, end, step);
   if (start <= 0) {
     if (step <= frac * steps) {
       ret = frac * end * step / steps;
@@ -212,7 +212,7 @@ interpolate(
   else {
     ret = db_to_value(value_to_db(start) + (value_to_db(end) - value_to_db(start)) *step /steps);
   }
-  LOG_DEBUG("Interpolated value: %f\n", ret);
+  LOG_DEBUG("Interpolated value: %f", ret);
   return ret;
 }
 
@@ -495,7 +495,7 @@ channel_set_midi_cc_volume_picked_up(
   jack_mixer_channel_t channel,
   bool status)
 {
-  LOG_DEBUG("Setting channel %s volume picked up to %d.\n", channel_ptr->name, status);
+  LOG_DEBUG("Setting channel %s volume picked up to %d.", channel_ptr->name, status);
   channel_ptr->midi_cc_volume_picked_up = status;
 }
 
@@ -504,7 +504,7 @@ channel_set_midi_cc_balance_picked_up(
   jack_mixer_channel_t channel,
   bool status)
 {
-  LOG_DEBUG("Setting channel %s balance picked up to %d.\n", channel_ptr->name, status);
+  LOG_DEBUG("Setting channel %s balance picked up to %d.", channel_ptr->name, status);
   channel_ptr->midi_cc_balance_picked_up = status;
 }
 
@@ -542,7 +542,7 @@ channel_autoset_volume_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_volume_index = i;
 
-      LOG_DEBUG("New channel \"%s\" volume mapped to CC#%i.\n", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" volume mapped to CC#%i.", channel_ptr->name, i);
       return i;
     }
   }
@@ -563,7 +563,7 @@ channel_autoset_balance_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_balance_index = i;
 
-      LOG_DEBUG("New channel \"%s\" balance mapped to CC#%i.\n", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" balance mapped to CC#%i.", channel_ptr->name, i);
       return i;
     }
   }
@@ -584,7 +584,7 @@ channel_autoset_mute_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_mute_index = i;
 
-      LOG_DEBUG("New channel \"%s\" mute mapped to CC#%i.\n", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" mute mapped to CC#%i.", channel_ptr->name, i);
       return i;
     }
   }
@@ -605,7 +605,7 @@ channel_autoset_solo_midi_cc(
       mixer_ptr->midi_cc_map[i] = channel_ptr;
       channel_ptr->midi_cc_solo_index = i;
 
-      LOG_DEBUG("New channel \"%s\" solo mapped to CC#%i.\n", channel_ptr->name, i);
+      LOG_DEBUG("New channel \"%s\" solo mapped to CC#%i.", channel_ptr->name, i);
       return i;
     }
   }
@@ -785,7 +785,7 @@ channel_volume_write(
     channel_ptr->midi_out_has_events |= CHANNEL_VOLUME;
   }
   channel_ptr->volume_new = value;
-  LOG_DEBUG("\"%s\" volume -> %f.\n", channel_ptr->name, value);
+  LOG_DEBUG("\"%s\" volume -> %f.", channel_ptr->name, value);
 }
 
 double
@@ -829,7 +829,7 @@ channel_balance_write(
     channel_ptr->midi_out_has_events |= CHANNEL_BALANCE;
   }
   channel_ptr->balance_new = balance;
-  LOG_DEBUG("\"%s\" balance -> %f\n", channel_ptr->name, balance);
+  LOG_DEBUG("\"%s\" balance -> %f", channel_ptr->name, balance);
 }
 
 double
@@ -876,7 +876,7 @@ channel_out_mute(
   if (!channel_ptr->out_mute) {
     channel_ptr->out_mute = true;
     channel_ptr->midi_out_has_events |= CHANNEL_MUTE;
-    LOG_DEBUG("\"%s\" muted.\n", channel_ptr->name);
+    LOG_DEBUG("\"%s\" muted.", channel_ptr->name);
   }
 }
 
@@ -887,7 +887,7 @@ channel_out_unmute(
   if (channel_ptr->out_mute) {
     channel_ptr->out_mute = false;
     channel_ptr->midi_out_has_events |= CHANNEL_MUTE;
-    LOG_DEBUG("\"%s\" un-muted.\n", channel_ptr->name);
+    LOG_DEBUG("\"%s\" un-muted.", channel_ptr->name);
   }
 }
 
@@ -906,7 +906,7 @@ channel_solo(
     return;
   channel_ptr->mixer_ptr->soloed_channels = g_slist_prepend(channel_ptr->mixer_ptr->soloed_channels, channel);
   channel_ptr->midi_out_has_events |= CHANNEL_SOLO;
-  LOG_DEBUG("\"%s\" soloed.\n", channel_ptr->name);
+  LOG_DEBUG("\"%s\" soloed.", channel_ptr->name);
 }
 
 void
@@ -917,7 +917,7 @@ channel_unsolo(
     return;
   channel_ptr->mixer_ptr->soloed_channels = g_slist_remove(channel_ptr->mixer_ptr->soloed_channels, channel);
   channel_ptr->midi_out_has_events |= CHANNEL_SOLO;
-  LOG_DEBUG("\"%s\" un-soloed.\n", channel_ptr->name);
+  LOG_DEBUG("\"%s\" un-soloed.", channel_ptr->name);
 }
 
 bool
@@ -1593,7 +1593,7 @@ process(
     cc_val = (uint8_t)(in_event.buffer[2] & 0x7F);
     mixer_ptr->last_midi_cc = (int8_t)cc_num;
 
-    LOG_DEBUG("%u: CC#%u -> %u\n", (unsigned int)(in_event.buffer[0]), cc_num, cc_val);
+    LOG_DEBUG("%u: CC#%u -> %u", (unsigned int)(in_event.buffer[0]), cc_num, cc_val);
 
     /* Do we have a mapping for particular CC? */
     channel_ptr = mixer_ptr->midi_cc_map[cc_num];
@@ -1705,7 +1705,7 @@ process(
                                                value_to_db(channel_ptr->volume_new)));
 
           LOG_DEBUG(
-            "%u: CC#%u <- %u\n",
+            "%u: CC#%u <- %u",
             (unsigned int)midi_out_buffer[0],
             (unsigned int)midi_out_buffer[1],
             (unsigned int)midi_out_buffer[2]);
@@ -1727,7 +1727,7 @@ process(
           }
 
           LOG_DEBUG(
-            "%u: CC#%u <- %u\n",
+            "%u: CC#%u <- %u",
             (unsigned int)midi_out_buffer[0],
             (unsigned int)midi_out_buffer[1],
             (unsigned int)midi_out_buffer[2]);
@@ -1743,7 +1743,7 @@ process(
           midi_out_buffer[2] = (unsigned char)(channel_is_out_muted(channel_ptr) ? 127 : 0);
 
           LOG_DEBUG(
-            "%u: CC#%u <- %u\n",
+            "%u: CC#%u <- %u",
             (unsigned int)midi_out_buffer[0],
             (unsigned int)midi_out_buffer[1],
             (unsigned int)midi_out_buffer[2]);
@@ -1759,7 +1759,7 @@ process(
           midi_out_buffer[2] = (unsigned char)(channel_is_soloed(channel_ptr) ? 127 : 0);
 
           LOG_DEBUG(
-            "%u: CC#%u <- %u\n",
+            "%u: CC#%u <- %u",
             (unsigned int)midi_out_buffer[0],
             (unsigned int)midi_out_buffer[1],
             (unsigned int)midi_out_buffer[2]);
@@ -1821,7 +1821,7 @@ create(
     mixer_ptr->midi_cc_map[i] = NULL;
   }
 
-  LOG_DEBUG("Initializing JACK.\n");
+  LOG_DEBUG("Initializing JACK.");
   mixer_ptr->jack_client = jack_client_open(jack_client_name_ptr, 0, NULL);
   if (mixer_ptr->jack_client == NULL)
   {
@@ -1829,8 +1829,8 @@ create(
     goto exit_destroy_mutex;
   }
 
-  LOG_DEBUG("JACK client created.\n");
-  LOG_DEBUG("Sample rate: %u\n", jack_get_sample_rate(mixer_ptr->jack_client));
+  LOG_DEBUG("JACK client created.");
+  LOG_DEBUG("Sample rate: %u", jack_get_sample_rate(mixer_ptr->jack_client));
 
 
 #if defined(HAVE_JACK_MIDI)
@@ -1895,7 +1895,7 @@ void
 destroy(
   jack_mixer_t mixer)
 {
-  LOG_DEBUG("Uninitializing JACK.\n");
+  LOG_DEBUG("Uninitializing JACK.");
   assert(mixer_ctx_ptr->jack_client != NULL);
   jack_client_close(mixer_ctx_ptr->jack_client);
   pthread_mutex_destroy(&mixer_ctx_ptr->mutex);

--- a/src/log.c
+++ b/src/log.c
@@ -18,6 +18,7 @@
  *
  *****************************************************************************/
 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -25,12 +26,15 @@
 
 #include "log.h"
 
+
 void jack_mixer_log(int level, const char * format, ...)
 {
   (void)level;
   va_list arglist;
 
   va_start(arglist, format);
-  vfprintf(stderr, format, arglist);
+  char format_with_name_prefix[512]; //512 string length for the log message. Buffer overflow risk negated by using snfprint:
+  snprintf(format_with_name_prefix, 512, "[jack_mixer] %s\n", format);
+  vfprintf(stderr, format_with_name_prefix, arglist);
   va_end(arglist);
 }


### PR DESCRIPTION
Prefix all log messages in C and Python with [jack_mixer] and unify/add newlines after log messages

No copyright required for this change. Only trivial code changes.