### PR TITLE
Sync output channel names with inputs on update

### DIFF
--- a/jack_mixer/channel.py
+++ b/jack_mixer/channel.py
@@ -1316,6 +1316,10 @@ class OutputChannelPropertiesDialog(ChannelPropertiesDialog):
 
     def on_response_cb(self, dlg, response_id, *args):
         if response_id == Gtk.ResponseType.APPLY:
+            name = self.entry_name.get_text()
+            if name != self.channel.channel_name:
+                self.channel.channel_name = name
+
             self.channel.display_solo_buttons = self.display_solo_buttons.get_active()
             self.channel.set_color(self.color_chooser_button.get_rgba())
             for inputchannel in self.app.channels:


### PR DESCRIPTION
Whenever an output channel name is changed we need to make sure all input channels have the correctly updated output channel name. This sync is already done for channel colors, but as the name was only set in the parent class, whereas the update already happens in OutputChannelPropertiesDialog class. To make sure the name is properly synced we duplicate setting the name and set it before all input channels are synced with the output channel currently being altered.