### PR TITLE
jack_mixer.desktop, add nsm keys

### DIFF
--- a/data/jack_mixer.desktop
+++ b/data/jack_mixer.desktop
@@ -10,3 +10,5 @@ Type=Application
 StartupNotify=true
 Categories=GTK;GNOME;AudioVideo;Player;Audio;
 Icon=jack_mixer
+X-NSM-Capable=true
+X-NSM-Exec=jack_mixer


### PR DESCRIPTION
This adds NSM related keys to the `*.desktop` file, so NSM tools can find applications which have NSM support.

`X-NSM-Capable`, is used to detect if the application has NSM support. It should ideally become false if the application is build without NSM support.

`X-NSM-Exec`, is the exec name of the application when used in NSM. It can't contain a path (not /usr/bin/ for example) or command line arguments like %f.

If `X-NSM-Exec` value is the same as the Exec value, then `X-NSM-Exec` is not strictly needed, but as the Exec value may change in the future (adding %f or something), I think it's not a bad thing to add it anyway.

As discussed in the nsmd forks issue tracker, https://github.com/jackaudio/new-session-manager/issues/40