### PR TITLE
Make raysessiondir configureable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,7 @@ datadir = join_paths(prefix, get_option('datadir'))
 #pythondir = join_paths(prefix, python.get_path('purelib'))
 desktopdir = join_paths(datadir, 'applications')
 icondir = join_paths(datadir, 'icons', 'hicolor')
-raysessiondir = join_paths('/', 'etc', 'xdg', 'raysession', 'client_templates', '35_jackmixer')
+raysessiondir = get_option('raysessiondir')
 
 # Build jack_mix_box and generate _jack_mixer extension source
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,3 +23,8 @@ option('wheel',
     value: false,
     description: 'Turn on build mode for creating a Python wheel (should not be used directly)'
 )
+option('raysessiondir',
+    type: 'string',
+    value: '/etc/xdg/raysession/client_templates/35_jackmixer',
+    description: 'Directory in which to place a RaySession integration configuration file'
+)


### PR DESCRIPTION
The meson build script assumes that it can write to `/etc` for the raysession configuration file, which is not possible on all systems.
All other destination directories respect the prefix, so this is the only one that causes a problem.

This PR makes it configureable, while retaining the original destination by default.